### PR TITLE
Add peerDependencies to package.json

### DIFF
--- a/projects/ngneat/transloco/package.json
+++ b/projects/ngneat/transloco/package.json
@@ -42,5 +42,9 @@
     "replace-in-file": "^4.1.2",
     "ora": "^3.4.0"
   },
+  "peerDependencies": {
+    "@angular/core": ">=4.3.0 <9.0.0",
+    "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
Peer dependencies were missing. This will cause errors on certain services. See: https://bundlephobia.com/result?p=@ngneat/transloco

This commit adds @angular/core and rxjs as peerDependencies of the library.