### PR TITLE
fix: 🐛 translation file extension in loader

### DIFF
--- a/schematics/src/ng-add/files/http-loader/transloco.loader.__ts__
+++ b/schematics/src/ng-add/files/http-loader/transloco.loader.__ts__
@@ -7,7 +7,7 @@ export class HttpLoader implements TranslocoLoader {
   constructor(private http: HttpClient) {}
 
   getTranslation(langPath: string) {
-    return this.http.get<Translation>(`/assets/i18n/${langPath}.json`);
+    return this.http.get<Translation>(`/assets/i18n/${langPath}.<%= fileType %>`);
   }
 }
 

--- a/schematics/src/ng-add/index.ts
+++ b/schematics/src/ng-add/index.ts
@@ -21,7 +21,7 @@ import { addImportToModule, insertImport, addProviderToModule } from '../utils/a
 import { InsertChange } from '../utils/change';
 import { findRootModule } from '../utils/find-module';
 import { getProject } from '../utils/projects';
-import { SchemaOptions, Loaders, TranslationFileTypes } from './schema';
+import { SchemaOptions, Loaders, TranslationFileTypes, translationFileExtensions } from './schema';
 
 function jsonTranslationFileCreator(source, lang) {
   return source.create(
@@ -111,11 +111,12 @@ export function addProvidersToModuleDeclaration(options: SchemaOptions, provider
   };
 }
 
-function getLoaderTemplates(loader, path): Source {
+function getLoaderTemplates(loader, fileType, path): Source {
   const loaderFolder = loader === Loaders.Webpack ? 'webpack-loader' : 'http-loader';
   return apply(url(`./files/${loaderFolder}`), [
     template({
-      ts: 'ts'
+      ts: 'ts',
+      fileType
     }),
     move('/', path)
   ]);
@@ -131,6 +132,8 @@ export default function(options: SchemaOptions): Rule {
     const rootModule = options.module;
 
     const assetsPath = options.path;
+
+    const fileType = translationFileExtensions[options.translateType];
 
     const translationCreator =
       options.translateType === TranslationFileTypes.Typescript
@@ -157,7 +160,7 @@ export default function(options: SchemaOptions): Rule {
             addImportsToModuleDeclaration(options, ['HttpClientModule'])
           ])
         : noop(),
-      mergeWith(getLoaderTemplates(options.loader, sourceRoot + '/' + rootModule)),
+      mergeWith(getLoaderTemplates(options.loader, fileType, sourceRoot + '/' + rootModule)),
       addImportsToModuleFile(options, ['environment'], '../environments/environment'),
       addImportsToModuleFile(options, ['translocoLoader'], './transloco.loader'),
       addImportsToModuleFile(options, ['TranslocoModule', 'TRANSLOCO_CONFIG', 'TranslocoConfig']),

--- a/schematics/src/ng-add/schema.ts
+++ b/schematics/src/ng-add/schema.ts
@@ -8,6 +8,11 @@ export enum TranslationFileTypes {
   JSON = 'JSON'
 }
 
+export const translationFileExtensions: { [key in keyof typeof TranslationFileTypes]: string } = {
+  JSON: 'json',
+  Typescript: 'ts'
+};
+
 export interface SchemaOptions {
   /**
    * The languages of the project.


### PR DESCRIPTION
fix translation file extension in loader which matches with chosen
translation file type

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
HttpLoader still loads `.json` files even TypeScript was picked when asked about Translation File Type using `ng add @ngneat/transloco`.

Issue Number: N/A

## What is the new behavior?
This PR will derive the `fileType` (extension) from `options.translationFileType` to be used in `loader` template.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```