### PR TITLE
feat(directive): add ability to read nested property

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This is the recommended approach. It's DRY and efficient, as it creates one subs
 </ng-template>
 ```
 
-If you are using `shared` strategy (default in the next major release), you can use `limit` to limit your translations to a particular nested property.
+If you are using `shared` strategy (default in the next major release), you can set `context` in your structural directive to get translations from a particular nested (including deeply nested) property.
 
 Given this translation object:
 
@@ -177,7 +177,7 @@ Given this translation object:
 you can do
 
 ```html
-<ng-container *transloco="let t; limit: 'dashboard'">
+<ng-container *transloco="let t; context: 'dashboard'">
   <h1>{{ t.title }}</h1>
   <p>{{ t.desc }}</p>
 </ng-container>

--- a/README.md
+++ b/README.md
@@ -157,6 +157,34 @@ This is the recommended approach. It's DRY and efficient, as it creates one subs
 </ng-template>
 ```
 
+If you are using `shared` strategy (default in the next major release), you can use `limit` to limit your translations to a particular nested property.
+
+Given this translation object:
+
+```typescript
+{
+  common: {
+    foo: 'Foo',
+    bar: 'Bar'
+  },
+  dashboard: {
+    title: 'Title',
+    desc: 'Desc'
+  }
+}
+```
+
+you can do
+
+```html
+<ng-container *transloco="let t; limit: 'dashboard'">
+  <h1>{{ t.title }}</h1>
+  <p>{{ t.desc }}</p>
+</ng-container>
+```
+
+without having to repeat the `dashboard` key.
+
 ### Using the Attribute Directive
 
 ```html
@@ -544,7 +572,7 @@ You can read more about it in [this article](https://netbasal.com/optimize-user-
 
 ## MessageFormat Support
 
-The library comes with support for [messageformat](https://messageformat.github.io/messageformat/).  
+The library comes with support for [messageformat](https://messageformat.github.io/messageformat/).
 Messageformat is a mechanism for handling both pluralization and gender in your app.
 
 You can see its format guide [here](https://messageformat.github.io/messageformat/page-guide).

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This is the recommended approach. It's DRY and efficient, as it creates one subs
 </ng-template>
 ```
 
-If you are using `shared` strategy (default in the next major release), you can set `context` in your structural directive to get translations from a particular nested (including deeply nested) property.
+If you are using `shared` strategy (default in the next major release), you can use `read` property in your structural directive to get translations of a particular nested (including deeply nested) property.
 
 Given this translation object:
 
@@ -177,13 +177,13 @@ Given this translation object:
 you can do
 
 ```html
-<ng-container *transloco="let t; context: 'dashboard'">
+<ng-container *transloco="let t; read: 'dashboard'">
   <h1>{{ t.title }}</h1>
   <p>{{ t.desc }}</p>
 </ng-container>
 ```
 
-without having to repeat the `dashboard` key.
+without having to repeat the `dashboard` key in each translation.
 
 ### Using the Attribute Directive
 

--- a/projects/ngneat/transloco/src/lib/tests/transloco.directive.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/transloco.directive.spec.ts
@@ -51,7 +51,7 @@ describe('TranslocoDirective', () => {
     expect(host.queryHost('div')).toHaveText('Admin Lazy spanish');
   }
 
-  function testLimitedTranslation(host: SpectatorWithHost<TranslocoDirective, HostComponent>) {
+  function testTranslationWithContext(host: SpectatorWithHost<TranslocoDirective, HostComponent>) {
     const service = host.get<TranslocoService>(TranslocoService);
     initScopeTest(host, service);
     expect(host.queryHost('div')).toHaveText('Title english');
@@ -196,9 +196,9 @@ describe('TranslocoDirective', () => {
       expect(host.queryHostAll('p')[1]).toHaveText('a.b.c value english');
     }));
 
-    it('should limit translation to a nested property', fakeAsync(() => {
-      host = createHost(`<section *transloco="let t; limit: 'nested'"><div>{{t.title}}</div></section>`, false);
-      testLimitedTranslation(host);
+    it('should get translation of a nested property using context', fakeAsync(() => {
+      host = createHost(`<section *transloco="let t; context: 'nested'"><div>{{t.title}}</div></section>`, false);
+      testTranslationWithContext(host);
     }));
   });
 

--- a/projects/ngneat/transloco/src/lib/tests/transloco.directive.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/transloco.directive.spec.ts
@@ -51,6 +51,16 @@ describe('TranslocoDirective', () => {
     expect(host.queryHost('div')).toHaveText('Admin Lazy spanish');
   }
 
+  function testLimitedTranslation(host: SpectatorWithHost<TranslocoDirective, HostComponent>) {
+    const service = host.get<TranslocoService>(TranslocoService);
+    initScopeTest(host, service);
+    expect(host.queryHost('div')).toHaveText('Title english');
+    service.setActiveLang('es');
+    runLoader();
+    host.detectChanges();
+    expect(host.queryHost('div')).toHaveText('Title spanish');
+  }
+
   it('should unsubscribe after one emit when not in listenToLangChange mode', fakeAsync(() => {
     host = createHost(`<div transloco="home"></div>`);
     runLoader();
@@ -185,6 +195,11 @@ describe('TranslocoDirective', () => {
       expect(host.queryHost('p')).toHaveText('a.b.c from list english');
       expect(host.queryHostAll('p')[1]).toHaveText('a.b.c value english');
     }));
+
+    it('should limit translation to a nested property', fakeAsync(() => {
+      host = createHost(`<section *transloco="let t; limit: 'nested'"><div>{{t.title}}</div></section>`, false);
+      testLimitedTranslation(host);
+    }));
   });
 
   describe('Loading Template', () => {
@@ -195,7 +210,7 @@ describe('TranslocoDirective', () => {
         <section *transloco="let t; scope: 'lazy-page'; loadingTpl: loading">
           <h1 data-cy="lazy-page">{{ t.title }}</h1>
         </section>
-        
+
         <ng-template #loading>
           <h1 id="lazy-page-loading">Loading...</h1>
         </ng-template>
@@ -252,7 +267,7 @@ describe('TranslocoDirective', () => {
         <section *transloco="let t; scope: 'lazy-page'; loadingTpl: loading">
           <h1 data-cy="lazy-page">{{ t.title }}</h1>
         </section>
-        
+
         <ng-template #loading>
           <h1 id="lazy-page-loading">Loading...</h1>
         </ng-template>

--- a/projects/ngneat/transloco/src/lib/tests/transloco.directive.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/transloco.directive.spec.ts
@@ -51,7 +51,7 @@ describe('TranslocoDirective', () => {
     expect(host.queryHost('div')).toHaveText('Admin Lazy spanish');
   }
 
-  function testTranslationWithContext(host: SpectatorWithHost<TranslocoDirective, HostComponent>) {
+  function testTranslationWithRead(host: SpectatorWithHost<TranslocoDirective, HostComponent>) {
     const service = host.get<TranslocoService>(TranslocoService);
     initScopeTest(host, service);
     expect(host.queryHost('div')).toHaveText('Title english');
@@ -196,9 +196,9 @@ describe('TranslocoDirective', () => {
       expect(host.queryHostAll('p')[1]).toHaveText('a.b.c value english');
     }));
 
-    it('should get translation of a nested property using context', fakeAsync(() => {
-      host = createHost(`<section *transloco="let t; context: 'nested'"><div>{{t.title}}</div></section>`, false);
-      testTranslationWithContext(host);
+    it('should get translation of a nested property using read', fakeAsync(() => {
+      host = createHost(`<section *transloco="let t; read: 'nested'"><div>{{t.title}}</div></section>`, false);
+      testTranslationWithRead(host);
     }));
   });
 

--- a/projects/ngneat/transloco/src/lib/transloco.directive.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.directive.ts
@@ -33,7 +33,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
   @Input('transloco') key: string;
   @Input('translocoParams') params: HashMap = {};
   @Input('translocoScope') inlineScope: string | undefined;
-  @Input('translocoContext') inlineContext: string | undefined;
+  @Input('translocoRead') inlineRead: string | undefined;
   @Input('translocoLang') inlineLang: string | undefined;
   @Input('translocoLoadingTpl') inlineTpl: TemplateRef<any> | undefined;
 
@@ -104,13 +104,13 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
   }
 
   private structuralStrategy(data: Translation) {
-    const dataWithContext = this.inlineContext ? getValue(data, this.inlineContext) : data;
+    const translations = this.inlineRead ? getValue(data, this.inlineRead) : data;
     if (this.view) {
-      this.view.context['$implicit'] = dataWithContext;
+      this.view.context['$implicit'] = translations;
     } else {
       this.detachLoader();
       this.view = this.vcr.createEmbeddedView(this.tpl, {
-        $implicit: dataWithContext
+        $implicit: translations
       });
     }
   }

--- a/projects/ngneat/transloco/src/lib/transloco.directive.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.directive.ts
@@ -21,6 +21,7 @@ import { TRANSLOCO_LOADING_TEMPLATE } from './transloco-loading-template';
 import { TRANSLOCO_SCOPE } from './transloco-scope';
 import { TranslocoService } from './transloco.service';
 import { HashMap, Translation } from './types';
+import { getValue } from './helpers';
 
 @Directive({
   selector: '[transloco]'
@@ -32,7 +33,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
   @Input('transloco') key: string;
   @Input('translocoParams') params: HashMap = {};
   @Input('translocoScope') inlineScope: string | undefined;
-  @Input('translocoLimit') inlineLimit: string | undefined;
+  @Input('translocoContext') inlineContext: string | undefined;
   @Input('translocoLang') inlineLang: string | undefined;
   @Input('translocoLoadingTpl') inlineTpl: TemplateRef<any> | undefined;
 
@@ -84,7 +85,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
         }
         const translation = this.translocoService.getTranslation(targetLang);
         this.langName = targetLang;
-        this.tpl === null ? this.simpleStrategy() : this.structuralStrategy(translation, this.inlineLimit);
+        this.tpl === null ? this.simpleStrategy() : this.structuralStrategy(translation);
         this.cdr.markForCheck();
         this.initialized = true;
       });
@@ -102,13 +103,14 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
     this.host.nativeElement.innerText = this.translocoService.translate(this.key, this.params, this.langName);
   }
 
-  private structuralStrategy(data: Translation, limit?: string) {
+  private structuralStrategy(data: Translation) {
+    const dataWithContext = this.inlineContext ? getValue(data, this.inlineContext) : data;
     if (this.view) {
-      this.view.context['$implicit'] = limit ? data[limit] : data;
+      this.view.context['$implicit'] = dataWithContext;
     } else {
       this.detachLoader();
       this.view = this.vcr.createEmbeddedView(this.tpl, {
-        $implicit: limit ? data[limit] : data
+        $implicit: dataWithContext
       });
     }
   }

--- a/projects/ngneat/transloco/src/lib/transloco.directive.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.directive.ts
@@ -32,6 +32,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
   @Input('transloco') key: string;
   @Input('translocoParams') params: HashMap = {};
   @Input('translocoScope') inlineScope: string | undefined;
+  @Input('translocoLimit') inlineLimit: string | undefined;
   @Input('translocoLang') inlineLang: string | undefined;
   @Input('translocoLoadingTpl') inlineTpl: TemplateRef<any> | undefined;
 
@@ -83,7 +84,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
         }
         const translation = this.translocoService.getTranslation(targetLang);
         this.langName = targetLang;
-        this.tpl === null ? this.simpleStrategy() : this.structuralStrategy(translation);
+        this.tpl === null ? this.simpleStrategy() : this.structuralStrategy(translation, this.inlineLimit);
         this.cdr.markForCheck();
         this.initialized = true;
       });
@@ -101,13 +102,13 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
     this.host.nativeElement.innerText = this.translocoService.translate(this.key, this.params, this.langName);
   }
 
-  private structuralStrategy(data: Translation) {
+  private structuralStrategy(data: Translation, limit?: string) {
     if (this.view) {
-      this.view.context['$implicit'] = data;
+      this.view.context['$implicit'] = limit ? data[limit] : data;
     } else {
       this.detachLoader();
       this.view = this.vcr.createEmbeddedView(this.tpl, {
-        $implicit: data
+        $implicit: limit ? data[limit] : data
       });
     }
   }

--- a/src/app/scope-sharing/scope-sharing.component.html
+++ b/src/app/scope-sharing/scope-sharing.component.html
@@ -26,3 +26,12 @@
 <h5><u>Pipe</u></h5>
 <p data-cy="p-todos-page-scope">{{ 'todos.title' | transloco }}</p>
 <p data-cy="p-global">{{ 'home' | transloco }}</p>
+
+<h5><u>Limiting the results to a nested property</u></h5>
+<code
+  ><pre>{{ ex.nested }}</pre></code
+>
+<ng-container *transloco="let t; limit: 'nested'">
+  <h5>{{ t.title }}</h5>
+  <p>{{ t.desc }}</p>
+</ng-container>

--- a/src/app/scope-sharing/scope-sharing.component.html
+++ b/src/app/scope-sharing/scope-sharing.component.html
@@ -27,11 +27,11 @@
 <p data-cy="p-todos-page-scope">{{ 'todos.title' | transloco }}</p>
 <p data-cy="p-global">{{ 'home' | transloco }}</p>
 
-<h5><u>Limiting the results to a nested property</u></h5>
+<h5><u>Settings a context to a nested property</u></h5>
 <code
   ><pre>{{ ex.nested }}</pre></code
 >
-<ng-container *transloco="let t; limit: 'nested'">
+<ng-container *transloco="let t; context: 'nested'">
   <h5>{{ t.title }}</h5>
   <p>{{ t.desc }}</p>
 </ng-container>

--- a/src/app/scope-sharing/scope-sharing.component.html
+++ b/src/app/scope-sharing/scope-sharing.component.html
@@ -27,11 +27,11 @@
 <p data-cy="p-todos-page-scope">{{ 'todos.title' | transloco }}</p>
 <p data-cy="p-global">{{ 'home' | transloco }}</p>
 
-<h5><u>Settings a context to a nested property</u></h5>
+<h5><u>Use read to get translations of a nested property</u></h5>
 <code
   ><pre>{{ ex.nested }}</pre></code
 >
-<ng-container *transloco="let t; context: 'nested'">
+<ng-container *transloco="let t; read: 'nested'">
   <h5>{{ t.title }}</h5>
   <p>{{ t.desc }}</p>
 </ng-container>

--- a/src/app/scope-sharing/scope-sharing.component.ts
+++ b/src/app/scope-sharing/scope-sharing.component.ts
@@ -15,6 +15,10 @@ export class ScopeSharingComponent implements OnInit {
     two: `  <ng-container *transloco="let t">
     <p>{{ t.todos.title }}</p>
     <p>{{ t.home }}</p>
+  </ng-container>`,
+    nested: `  <ng-container *transloco="let t; limit: 'nested'">
+    <h5>{{ t.title }}</h5>
+    <p>{{ t.desc }}</p>
   </ng-container>`
   };
 

--- a/src/app/scope-sharing/scope-sharing.component.ts
+++ b/src/app/scope-sharing/scope-sharing.component.ts
@@ -16,7 +16,7 @@ export class ScopeSharingComponent implements OnInit {
     <p>{{ t.todos.title }}</p>
     <p>{{ t.home }}</p>
   </ng-container>`,
-    nested: `  <ng-container *transloco="let t; limit: 'nested'">
+    nested: `  <ng-container *transloco="let t; context: 'nested'">
     <h5>{{ t.title }}</h5>
     <p>{{ t.desc }}</p>
   </ng-container>`

--- a/src/app/scope-sharing/scope-sharing.component.ts
+++ b/src/app/scope-sharing/scope-sharing.component.ts
@@ -16,7 +16,7 @@ export class ScopeSharingComponent implements OnInit {
     <p>{{ t.todos.title }}</p>
     <p>{{ t.home }}</p>
   </ng-container>`,
-    nested: `  <ng-container *transloco="let t; context: 'nested'">
+    nested: `  <ng-container *transloco="let t; read: 'nested'">
     <h5>{{ t.title }}</h5>
     <p>{{ t.desc }}</p>
   </ng-container>`

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -9,5 +9,9 @@
   },
   "b": "b english",
   "c": "c english",
+  "nested": {
+    "title": "Title english",
+    "desc": "Desc english"
+  },
   "key.is.like.path": "key is like path"
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -8,5 +8,9 @@
     }
   },
   "b": "b spanish",
-  "c": "c spanish"
+  "c": "c spanish",
+  "nested": {
+    "title": "Title spanish",
+    "desc": "Desc spanish"
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Adds ability to limit a translation to a nested property so you don't have to write the full path in each translation.

Given this:

```typescript
{
  common: {
    foo: 'Foo',
    bar: 'Bar'
  },
  dashboard: {
    title: 'Title',
    desc: 'Desc'
  }
}
```

you can do

```html
<ng-container *transloco="let t; limit: 'dashboard'">
  <h1>{{ t.title }}</h1>
  <p>{{ t.desc }}</p>
</ng-container>
```

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #41

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

1. not sure about the naming
2. should it support deeply nested properies `dashboard.some.deeply.nested.obj`? 

@NetanelBasal 