### PR TITLE
Inconsistance with MessageFormat.Options interface

### DIFF
--- a/projects/ngneat/transloco-messageformat/README.md
+++ b/projects/ngneat/transloco-messageformat/README.md
@@ -74,7 +74,7 @@ This is how you would enable bi-directional support and add a custom formatter, 
     TranslocoMessageFormatModule.init(
       {
         biDiSupport: true,
-        formatters: { upcase: v => v.toUpperCase() }
+        customFormatters: { upcase: v => v.toUpperCase() }
       }
     )
   ]


### PR DESCRIPTION
It should be `customFormatters` instead of `formatters`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Information in Readme.MD not consistant with the source code.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
