### PR TITLE
Update BREAKING_CHANGES.md

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -35,7 +35,7 @@ We also made minor changes in `TranslocoConfig`:
 {
   provide: TRANSLOCO_CONFIG,
   useValue: {
-    availabeLangs: ['en', 'es'],
+    availableLangs: ['en', 'es'],
     reRenderOnLangChange: true
   }
 }


### PR DESCRIPTION
Fixed typo in example. Missing 'l' in 'availableLangs'.

Since I started the migration without the upgrade tool by hand (didn't know it exists and its mentioned at the end of the doc), I just copied this example to my project and spent some time finding out whats the problem.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
