### PR TITLE
feat: access to active language and up-to-date config in MissingHandler

### DIFF
--- a/projects/ngneat/transloco/src/lib/transloco-missing-handler.ts
+++ b/projects/ngneat/transloco/src/lib/transloco-missing-handler.ts
@@ -3,8 +3,12 @@ import { TranslocoConfig } from './transloco.config';
 
 export const TRANSLOCO_MISSING_HANDLER = new InjectionToken('TRANSLOCO_MISSING_HANDLER');
 
+export interface TranslocoMissingInfo extends TranslocoConfig {
+  activeLang: string;
+}
+
 export interface TranslocoMissingHandler {
-  handle(key: string, config: TranslocoConfig): any;
+  handle(key: string, info: TranslocoMissingInfo): any;
 }
 
 export class DefaultHandler implements TranslocoMissingHandler {

--- a/projects/ngneat/transloco/src/lib/transloco-missing-handler.ts
+++ b/projects/ngneat/transloco/src/lib/transloco-missing-handler.ts
@@ -3,12 +3,12 @@ import { TranslocoConfig } from './transloco.config';
 
 export const TRANSLOCO_MISSING_HANDLER = new InjectionToken('TRANSLOCO_MISSING_HANDLER');
 
-export interface TranslocoMissingInfo extends TranslocoConfig {
+export interface TranslocoMissingHandlerData extends TranslocoConfig {
   activeLang: string;
 }
 
 export interface TranslocoMissingHandler {
-  handle(key: string, info: TranslocoMissingInfo): any;
+  handle(key: string, data: TranslocoMissingHandlerData): any;
 }
 
 export class DefaultHandler implements TranslocoMissingHandler {

--- a/projects/ngneat/transloco/src/lib/transloco.service.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.service.ts
@@ -15,7 +15,7 @@ import {
 } from './types';
 import { flatten, getValue, isString, size, toCamelCase, unflatten } from './helpers';
 import { defaultConfig, TRANSLOCO_CONFIG, TranslocoConfig } from './transloco.config';
-import { TRANSLOCO_MISSING_HANDLER, TranslocoMissingHandler } from './transloco-missing-handler';
+import { TRANSLOCO_MISSING_HANDLER, TranslocoMissingHandler, TranslocoMissingInfo } from './transloco-missing-handler';
 import { TRANSLOCO_INTERCEPTOR, TranslocoInterceptor } from './transloco.interceptor';
 import { TRANSLOCO_FALLBACK_STRATEGY, TranslocoFallbackStrategy } from './transloco-fallback-strategy';
 import { mergeConfig } from './merge-config';
@@ -189,7 +189,7 @@ export class TranslocoService implements OnDestroy {
     key = scope ? `${scope}.${key}` : key;
 
     if (!key) {
-      return this.missingHandler.handle(key, this.config);
+      return this.missingHandler.handle(key, this.getMissingInfo());
     }
 
     const translation = this.getTranslation(resolveLang);
@@ -361,7 +361,7 @@ export class TranslocoService implements OnDestroy {
       return value;
     }
 
-    return this.missingHandler.handle(key, this.config);
+    return this.missingHandler.handle(key, this.getMissingInfo());
   }
 
   /**
@@ -430,6 +430,15 @@ export class TranslocoService implements OnDestroy {
     }
 
     return (this.getAvailableLangs() as { id: string }[]).map(l => l.id);
+  }
+
+  private getMissingInfo(): TranslocoMissingInfo {
+    return {
+      ...this.config,
+      activeLang: this.getActiveLang(),
+      availableLangs: this.availableLangs,
+      defaultLang: this.defaultLang
+    };
   }
 
   private useFallbackTranslation(lang?: string) {

--- a/projects/ngneat/transloco/src/lib/transloco.service.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.service.ts
@@ -15,7 +15,7 @@ import {
 } from './types';
 import { flatten, getValue, isString, size, toCamelCase, unflatten } from './helpers';
 import { defaultConfig, TRANSLOCO_CONFIG, TranslocoConfig } from './transloco.config';
-import { TRANSLOCO_MISSING_HANDLER, TranslocoMissingHandler, TranslocoMissingInfo } from './transloco-missing-handler';
+import { TRANSLOCO_MISSING_HANDLER, TranslocoMissingHandler, TranslocoMissingHandlerData } from './transloco-missing-handler';
 import { TRANSLOCO_INTERCEPTOR, TranslocoInterceptor } from './transloco.interceptor';
 import { TRANSLOCO_FALLBACK_STRATEGY, TranslocoFallbackStrategy } from './transloco-fallback-strategy';
 import { mergeConfig } from './merge-config';
@@ -432,7 +432,7 @@ export class TranslocoService implements OnDestroy {
     return (this.getAvailableLangs() as { id: string }[]).map(l => l.id);
   }
 
-  private getMissingInfo(): TranslocoMissingInfo {
+  private getMissingInfo(): TranslocoMissingHandlerData {
     return {
       ...this.config,
       activeLang: this.getActiveLang(),

--- a/projects/ngneat/transloco/src/lib/transloco.service.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.service.ts
@@ -189,7 +189,7 @@ export class TranslocoService implements OnDestroy {
     key = scope ? `${scope}.${key}` : key;
 
     if (!key) {
-      return this.missingHandler.handle(key, this.getMissingInfo());
+      return this.missingHandler.handle(key, this.getMissingHandlerData());
     }
 
     const translation = this.getTranslation(resolveLang);
@@ -361,7 +361,7 @@ export class TranslocoService implements OnDestroy {
       return value;
     }
 
-    return this.missingHandler.handle(key, this.getMissingInfo());
+    return this.missingHandler.handle(key, this.getMissingHandlerData());
   }
 
   /**
@@ -432,7 +432,7 @@ export class TranslocoService implements OnDestroy {
     return (this.getAvailableLangs() as { id: string }[]).map(l => l.id);
   }
 
-  private getMissingInfo(): TranslocoMissingHandlerData {
+  private getMissingHandlerData(): TranslocoMissingHandlerData {
     return {
       ...this.config,
       activeLang: this.getActiveLang(),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- There is no access to `activeLang` in the missing key handler. 
- `defaultLang` and `availableLangs` could be out-of-date

Issue Number: Closes #164

## What is the new behavior?
- Include `activeLang` in the info object passed to `MissingHandler.handle()`
- Pass up-to-date versions of aforementioned properties

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
**Questions**  
I searched for a way to update the docs at <https://netbasal.gitbook.io/transloco/hack-the-library/transloco-missing-handler> but couldn't find anything related in the repo. Have I missed something?

I saw you have a contributors file, am I supposed to add myself to it? And if so, with what _contributions_ (code, ideas)?

I could not find any info regarding this in CONTRIBUTING.md file.