### PR TITLE
fix: Provide multiple values for TRANSLOCO_SCOPE to support lazy loading multiple json files

### DIFF
--- a/cypress/integration/full-cycle.spec.ts
+++ b/cypress/integration/full-cycle.spec.ts
@@ -34,6 +34,17 @@ describe('Transloco Full Cycle', () => {
     changeLang('en');
     generateContentWithoutLoader();
 
+    cy.visit('/lazy-multiple-scopes');
+    /* it should display lazy translation */
+    changeLang('es');
+    generateLazyContent('spanish');
+    changeLang('en');
+    generateLazyContent();
+    /* should not display loader template after loaded once */
+    changeLang('es');
+    changeLang('en');
+    generateContentWithoutLoader();
+
     /* Test scope sharing page */
 
     cy.visit('scope-sharing');

--- a/cypress/integration/lazy.ts
+++ b/cypress/integration/lazy.ts
@@ -8,6 +8,7 @@ export function generateLazyContent(lang = 'english') {
   cy.get(`[data-cy=regular]`).should('contain', `Admin ${lang}`);
   cy.get(`[data-cy=read]`).should('contain', `Admin read ${lang}`);
   cy.get(`[data-cy=lazy-page]`).should('contain', `Admin Lazy ${lang}`);
+  cy.get(`[data-cy=multiple-scopes]`).should('contain', `Admin ${lang}`);
 }
 
 export function generateContentWithoutLoader() {

--- a/projects/ngneat/transloco/src/lib/scope-resolver.ts
+++ b/projects/ngneat/transloco/src/lib/scope-resolver.ts
@@ -1,10 +1,10 @@
-import { TranslocoScope, ProviderScope } from './types';
+import { TranslocoScope, ProviderScope, MaybeArray } from './types';
 import { TranslocoService } from './transloco.service';
 import { isScopeObject, toCamelCase } from './helpers';
 
 type ScopeResolverParams = {
   inline: string | undefined;
-  provider: TranslocoScope;
+  provider: MaybeArray<TranslocoScope>;
 };
 
 export class ScopeResolver {

--- a/projects/ngneat/transloco/src/lib/tests/directive/multi-scope-alias.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/directive/multi-scope-alias.spec.ts
@@ -1,0 +1,91 @@
+import { fakeAsync } from '@angular/core/testing';
+import { TRANSLOCO_SCOPE, TranslocoDirective, TranslocoModule } from '@ngneat/transloco';
+import { createComponentFactory, Spectator, SpectatorHost } from '@ngneat/spectator';
+import { createFactory } from './shared';
+import { providersMock, runLoader } from '../transloco.mocks';
+import { Component } from '@angular/core';
+
+describe('Scope alias', () => {
+  let spectator: SpectatorHost<TranslocoDirective>;
+
+  const createHost = createFactory([
+    {
+      provide: TRANSLOCO_SCOPE,
+      useValue: {
+        scope: 'admin-page',
+        alias: 'adminPageAlias'
+      },
+      multi: true
+    },
+    {
+      provide: TRANSLOCO_SCOPE,
+      useValue: {
+        scope: 'lazy-page',
+        alias: 'lazyPage'
+      },
+      multi: true
+    }
+  ]);
+
+  it('should support multiple scopes with aliases', fakeAsync(() => {
+    spectator = createHost(`
+        <section *transloco="let t;">
+          <div>
+            {{t('adminPageAlias.title')}}<br />
+            {{t('lazyPage.title')}}
+          </div>
+        </section>
+    `);
+    runLoader();
+    runLoader();
+    spectator.detectChanges();
+    expect(spectator.query('div')).toHaveText('Admin english', false);
+    expect(spectator.query('div')).toHaveText('Admin Lazy english', false);
+  }));
+});
+
+@Component({
+  template: `
+    <p>{{ 'lazy.title' | transloco }}</p>
+    <span>{{ 'admin.title' | transloco }}</span>
+    <h1>{{ 'nested.title' | transloco }}</h1>
+  `
+})
+class TestPipe {
+}
+
+describe('Scope alias pipe', () => {
+  let spectator: Spectator<TestPipe>;
+  const createComponent = createComponentFactory({
+    component: TestPipe,
+    imports: [TranslocoModule],
+    providers: [
+      providersMock,
+      {
+        provide: TRANSLOCO_SCOPE,
+        useValue: {
+          scope: 'lazy-page',
+          alias: 'lazy'
+        },
+        multi: true
+      },
+      {
+        provide: TRANSLOCO_SCOPE,
+        useValue: {
+          scope: 'admin-page',
+          alias: 'admin'
+        },
+        multi: true
+      }
+    ]
+  });
+
+  it('should support multiple scope aliasses', fakeAsync(() => {
+    spectator = createComponent();
+    runLoader();
+    runLoader();
+    spectator.detectChanges();
+    expect(spectator.query('p')).toHaveText('Admin Lazy english');
+    expect(spectator.query('span')).toHaveText('Admin english');
+  }));
+});

--- a/projects/ngneat/transloco/src/lib/tests/pipe/pipe.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/pipe/pipe.spec.ts
@@ -53,6 +53,28 @@ describe('TranslocoPipe', () => {
     expect(translateServiceMock.translate).toHaveBeenCalledWith('title', {}, 'es');
   }));
 
+  it('should load scope translation with multiple provided scopes', fakeAsync(() => {
+    spyOn(translateServiceMock, 'translate').and.callThrough();
+    pipe = new TranslocoPipe(translateServiceMock, [{ scope: 'lazy-page', alias: 'lazyPageAlias' }, { scope: 'admin-page', alias: 'adminPageAlias' }], null, cdrMock);
+    (pipe as any).listenToLangChange = true;
+    pipe.transform('lazyPageAlias.title', {});
+    runLoader();
+    expect(translateServiceMock.translate).toHaveBeenCalledWith('lazyPageAlias.title', {}, 'en');
+
+    pipe.transform('adminPageAlias.title', {});
+    runLoader();
+    expect(translateServiceMock.translate).toHaveBeenCalledWith('adminPageAlias.title', {}, 'en');
+
+    translateServiceMock.setActiveLang('es');
+    pipe.transform('lazyPageAlias.title', {});
+    runLoader();
+    expect(translateServiceMock.translate).toHaveBeenCalledWith('lazyPageAlias.title', {}, 'es');
+
+    pipe.transform('adminPageAlias.title', {});
+    runLoader();
+    expect(translateServiceMock.translate).toHaveBeenCalledWith('adminPageAlias.title', {}, 'es');
+  }));
+
   describe('updateValue', () => {
     it('should update the value, set the cache and mark for check', fakeAsync(() => {
       const key = 'home';

--- a/projects/ngneat/transloco/src/lib/tests/transloco.mocks.ts
+++ b/projects/ngneat/transloco/src/lib/tests/transloco.mocks.ts
@@ -8,6 +8,8 @@ import en from '../../../../../../src/assets/i18n/en.json';
 import es from '../../../../../../src/assets/i18n/es.json';
 import enLazy from '../../../../../../src/assets/i18n/lazy-page/en.json';
 import esLazy from '../../../../../../src/assets/i18n/lazy-page/es.json';
+import enAdmin from '../../../../../../src/assets/i18n/admin-page/en.json';
+import esAdmin from '../../../../../../src/assets/i18n/admin-page/es.json';
 import enLazyScopeAlias from '../../../../../../src/assets/i18n/lazy-scope-alias/en.json';
 import esLazyScopeAlias from '../../../../../../src/assets/i18n/lazy-scope-alias/es.json';
 import enMF from '../../../../../../src/assets/i18n/transpilers/messageformat/en.json';
@@ -24,6 +26,8 @@ export const mockLangs = {
   es,
   'lazy-page/en': enLazy,
   'lazy-page/es': esLazy,
+  'admin-page/en': enAdmin,
+  'admin-page/es': esAdmin,
   'lazy-scope-alias/en': enLazyScopeAlias,
   'lazy-scope-alias/es': esLazyScopeAlias,
   'transpilers/messageformat/en': enMF,

--- a/projects/ngneat/transloco/src/lib/transloco.pipe.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.pipe.ts
@@ -1,8 +1,8 @@
-import { ChangeDetectorRef, Inject, OnDestroy, Optional, Pipe, PipeTransform } from '@angular/core';
+import { ChangeDetectorRef, Inject, OnDestroy, Optional, Pipe, PipeTransform, Provider } from '@angular/core';
 import { TranslocoService } from './transloco.service';
-import { HashMap, ProviderScope } from './types';
+import { HashMap, ProviderScope, Translation } from './types';
 import { switchMap } from 'rxjs/operators';
-import { Subscription } from 'rxjs';
+import { forkJoin, Observable, Subscription } from 'rxjs';
 import { TRANSLOCO_SCOPE } from './transloco-scope';
 import { TRANSLOCO_LANG } from './transloco-lang';
 import { listenOrNotOperator, resolveInlineLoader, shouldListenToLangChanges } from './shared';
@@ -24,7 +24,7 @@ export class TranslocoPipe implements PipeTransform, OnDestroy {
 
   constructor(
     private translocoService: TranslocoService,
-    @Optional() @Inject(TRANSLOCO_SCOPE) private providerScope: string | ProviderScope | null,
+    @Optional() @Inject(TRANSLOCO_SCOPE) private providerScope: string | string[] | ProviderScope | ProviderScope[] | null,
     @Optional() @Inject(TRANSLOCO_LANG) private providerLang: string | null,
     private cdr: ChangeDetectorRef
   ) {
@@ -54,12 +54,9 @@ export class TranslocoPipe implements PipeTransform, OnDestroy {
             active: activeLang
           });
 
-          let scope = this.scopeResolver.resolve({ inline: undefined, provider: this.providerScope });
-          this.path = this.langResolver.resolveLangPath(lang, scope);
-
-          const inlineLoader = resolveInlineLoader(this.providerScope, scope);
-
-          return this.translocoService._loadDependencies(this.path, inlineLoader);
+          return (Array.isArray(this.providerScope)) ?
+            forkJoin((<any>this.providerScope).map(x => this.resolveScope(lang, x)))
+            : this.resolveScope(lang, this.providerScope);
         }),
         listenOrNotOperator(this.listenToLangChange)
       )
@@ -76,5 +73,14 @@ export class TranslocoPipe implements PipeTransform, OnDestroy {
     const lang = this.langResolver.resolveLangBasedOnScope(this.path);
     this.lastValue = this.translocoService.translate(key, params, lang);
     this.cdr.markForCheck();
+  }
+
+  private resolveScope(lang: string, providerScope: string | ProviderScope | null) {
+    let resolvedScope = this.scopeResolver.resolve({ inline: undefined, provider: providerScope });
+    this.path = this.langResolver.resolveLangPath(lang, resolvedScope);
+
+    const inlineLoader = resolveInlineLoader(providerScope, resolvedScope);
+
+    return this.translocoService._loadDependencies(this.path, inlineLoader);
   }
 }

--- a/projects/ngneat/transloco/src/lib/transloco.service.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.service.ts
@@ -117,10 +117,10 @@ export class TranslocoService implements OnDestroy {
 
   load(path: string, options: LoadOptions = {}): Observable<Translation> {
     if (this.cache.has(path) === false) {
+
       let loadTranslation: Observable<Translation | { translation: Translation; lang: string }[]>;
       const isScope = this._isLangScoped(path);
       const scope = isScope ? getScopeFromLang(path) : null;
-
       if (this.useFallbackTranslation(path)) {
         // if the path is scope the fallback should be `scope/fallbackLang`;
         const fallback = isScope ? `${scope}/${this.firstFallbackLang}` : this.firstFallbackLang;
@@ -337,6 +337,7 @@ export class TranslocoService implements OnDestroy {
       ...this.getTranslation(lang),
       [key]: withHook
     };
+
     this.setTranslation(newValue, lang);
   }
 
@@ -394,7 +395,6 @@ export class TranslocoService implements OnDestroy {
     if (this._isLangScoped(path) && !this.isLoadedTranslation(mainLang)) {
       return combineLatest(this.load(mainLang), this.load(path, { inlineLoader }));
     }
-
     return this.load(path, { inlineLoader });
   }
 

--- a/projects/ngneat/transloco/src/lib/types.ts
+++ b/projects/ngneat/transloco/src/lib/types.ts
@@ -27,6 +27,7 @@ export type ProviderScope = {
   loader?: InlineLoader;
   alias?: string;
 };
+export type MaybeArray<T> = T | T[];
 export type TranslocoScope = ProviderScope | string | undefined;
 export type InlineLoader = HashMap<() => Promise<Translation>>;
 export type LoadOptions = { fallbackLangs?: string[] | null; inlineLoader?: InlineLoader | null };

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -21,6 +21,10 @@ const routes: Routes = [
     loadChildren: './lazy-scope-alias/lazy-scope-alias.module#LazyScopeAliasModule'
   },
   {
+    path: 'lazy-multiple-scopes',
+    loadChildren: './lazy-multiple-scopes/lazy-multiple-scopes.module#LazyMultipleScopesModule'
+  },
+  {
     path: 'scope-sharing',
     loadChildren: './scope-sharing/scope-sharing.module#ScopeSharingModule'
   },

--- a/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.html
+++ b/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.html
@@ -1,15 +1,24 @@
 <h4>Two scopes are defined in this module:</h4>
 <p data-cy="multiple-scopes">
-  admin-page: {{'AdminPageAlias.title' | transloco}}<br />
-  lazy-page: {{'LazyPageAlias.title' | transloco}}</p>
+  admin-page: <span class="admin-page-title">{{'AdminPageAlias.title' | transloco}}</span><br />
+  lazy-page: <span class="lazy-page-title">{{'LazyPageAlias.title' | transloco}}</span></p>
 
 <h4>Two scopes using structural directives:</h4>
 <ng-container *transloco="let t">
+  admin-page:<br />
   <p data-cy="regular">{{ t('AdminPageAlias.title') }}</p>
-  <p data-cy="lazy-page">{{ t('LazyPageAlias.title') }}</p>
+</ng-container>
+<ng-container *transloco="let t">
+  lazy-page:<br />
+  <p data-cy="regular">{{ t('LazyPageAlias.title') }}</p>
 </ng-container>
 
+<h4>Two scopes using structural directives (using read):</h4>
 <ng-container *transloco="let t; read: 'AdminPageAlias'">
-  <p data-cy="read" class="admin-read">{{ t('read') }}</p>
+  admin-page: <p data-cy="read" class="admin-read">{{ t('read') }}</p>
+</ng-container>
+
+<ng-container *transloco="let t; read: 'LazyPageAlias'">
+  lazy-page: <p data-cy="read" class="admin-read">{{ t('title') }}</p>
 </ng-container>
 

--- a/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.html
+++ b/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.html
@@ -1,0 +1,20 @@
+<h4>Two scopes are defined in this module:</h4>
+<p data-cy="multiple-scopes">
+  admin-page: {{'AdminPageAlias.title' | transloco}}<br />
+  lazy-page: {{'LazyPageAlias.title' | transloco}}</p>
+
+<h4>Two scopes using structural directives:</h4>
+<ng-container *transloco="let t">
+  <p data-cy="multiple-scopes-structural-one">{{ t('AdminPageAlias.title') }}</p>
+  <p data-cy="multiple-scopes-structural-two">{{ t('LazyPageAlias.title') }}</p>
+</ng-container>
+
+<ng-container *transloco="let t; read: 'AdminPageAlias'">
+  <p data-cy="multiple-scopes-structural-three" class="admin-read">{{ t('read') }}</p>
+</ng-container>
+
+<ng-container *transloco="let t; scope: 'lazy-scope-alias';">
+  <p data-cy="multiple-scopes-structural-four">{{ t('lazyScopeAlias.title') }}</p>
+</ng-container>
+
+

--- a/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.html
+++ b/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.html
@@ -5,16 +5,11 @@
 
 <h4>Two scopes using structural directives:</h4>
 <ng-container *transloco="let t">
-  <p data-cy="multiple-scopes-structural-one">{{ t('AdminPageAlias.title') }}</p>
-  <p data-cy="multiple-scopes-structural-two">{{ t('LazyPageAlias.title') }}</p>
+  <p data-cy="regular">{{ t('AdminPageAlias.title') }}</p>
+  <p data-cy="lazy-page">{{ t('LazyPageAlias.title') }}</p>
 </ng-container>
 
 <ng-container *transloco="let t; read: 'AdminPageAlias'">
-  <p data-cy="multiple-scopes-structural-three" class="admin-read">{{ t('read') }}</p>
+  <p data-cy="read" class="admin-read">{{ t('read') }}</p>
 </ng-container>
-
-<ng-container *transloco="let t; scope: 'lazy-scope-alias';">
-  <p data-cy="multiple-scopes-structural-four">{{ t('lazyScopeAlias.title') }}</p>
-</ng-container>
-
 

--- a/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.spec.ts
+++ b/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LazyMultipleScopesComponent } from './lazy-multiple-scopes.component';
+
+describe('LazyMultipleScopesComponent', () => {
+  let component: LazyMultipleScopesComponent;
+  let fixture: ComponentFixture<LazyMultipleScopesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LazyMultipleScopesComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LazyMultipleScopesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.spec.ts
+++ b/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.spec.ts
@@ -1,25 +1,32 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { LazyMultipleScopesComponent } from './lazy-multiple-scopes.component';
+import { TRANSLOCO_SCOPE, TranslocoService } from '@ngneat/transloco';
+import { getTranslocoModule } from '../transloco-testing.module';
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
 
 describe('LazyMultipleScopesComponent', () => {
-  let component: LazyMultipleScopesComponent;
-  let fixture: ComponentFixture<LazyMultipleScopesComponent>;
+  let spectator: Spectator<LazyMultipleScopesComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ LazyMultipleScopesComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(LazyMultipleScopesComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  let createComponent = createComponentFactory({
+    providers: [
+      { provide: TRANSLOCO_SCOPE, useValue: { scope: 'admin-page', alias: 'AdminPageAlias'}, multi: true},
+      { provide: TRANSLOCO_SCOPE, useValue: { scope: 'lazy-page', alias: 'LazyPageAlias' }, multi: true}
+    ],
+    imports: [getTranslocoModule({
+      reRenderOnLangChange: true
+    })],
+    component: LazyMultipleScopesComponent
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  beforeEach(() => (spectator = createComponent()));
+
+  it('should read two scopes on the same component', () => {
+    spectator.fixture.detectChanges();
+    expect(spectator.query('.admin-page-title')).toHaveText('Admin spanish');
+    expect(spectator.query('.lazy-page-title')).toHaveText('Admin Lazy spanish');
+    const service = spectator.get(TranslocoService);
+    service.setActiveLang('en');
+    spectator.detectChanges();
+    expect(spectator.query('.admin-page-title')).toHaveText('Admin english');
+    expect(spectator.query('.lazy-page-title')).toHaveText('Admin Lazy english');
   });
 });

--- a/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.ts
+++ b/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { TRANSLOCO_SCOPE } from '@ngneat/transloco';
+
+@Component({
+  selector: 'app-lazy-multiple-scopes',
+  templateUrl: './lazy-multiple-scopes.component.html',
+  styleUrls: ['./lazy-multiple-scopes.component.css'],
+  providers: [
+    { provide: TRANSLOCO_SCOPE, useValue: { scope: 'admin-page', alias: 'AdminPageAlias'}, multi: true},
+    { provide: TRANSLOCO_SCOPE, useValue: { scope: 'lazy-page', alias: 'LazyPageAlias' }, multi: true}
+  ]
+})
+export class LazyMultipleScopesComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.ts
+++ b/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.ts
@@ -4,7 +4,6 @@ import { TRANSLOCO_SCOPE } from '@ngneat/transloco';
 @Component({
   selector: 'app-lazy-multiple-scopes',
   templateUrl: './lazy-multiple-scopes.component.html',
-  styleUrls: ['./lazy-multiple-scopes.component.css'],
   providers: [
     { provide: TRANSLOCO_SCOPE, useValue: { scope: 'admin-page', alias: 'AdminPageAlias'}, multi: true},
     { provide: TRANSLOCO_SCOPE, useValue: { scope: 'lazy-page', alias: 'LazyPageAlias' }, multi: true}

--- a/src/app/lazy-multiple-scopes/lazy-multiple-scopes.module.ts
+++ b/src/app/lazy-multiple-scopes/lazy-multiple-scopes.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { LazyComponent } from '../lazy/lazy.component';
+import { LazyMultipleScopesComponent } from './lazy-multiple-scopes.component';
+import { TRANSLOCO_LOADING_TEMPLATE, TRANSLOCO_SCOPE, TranslocoModule } from '@ngneat/transloco';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: LazyMultipleScopesComponent
+  }
+];
+
+
+@NgModule({
+  declarations: [LazyMultipleScopesComponent],
+  providers: [
+    {
+      provide: TRANSLOCO_LOADING_TEMPLATE,
+      useValue: `<span id="default-loading-template">Loading template...</span>`
+    }
+  ],
+  imports: [CommonModule, RouterModule.forChild(routes), TranslocoModule]
+})
+export class LazyMultipleScopesModule { }

--- a/src/app/lazy/lazy.module.ts
+++ b/src/app/lazy/lazy.module.ts
@@ -22,4 +22,5 @@ const routes: Routes = [
   ],
   imports: [CommonModule, RouterModule.forChild(routes), TranslocoModule]
 })
-export class LazyModule {}
+export class LazyModule {
+}

--- a/src/app/transloco-testing.module.ts
+++ b/src/app/transloco-testing.module.ts
@@ -3,6 +3,8 @@ import en from '../assets/i18n/en.json';
 import es from '../assets/i18n/es.json';
 import admin from '../assets/i18n/admin-page/en.json';
 import adminSpanish from '../assets/i18n/admin-page/es.json';
+import lazy from '../assets/i18n/lazy-page/en.json';
+import lazySpanish from '../assets/i18n/lazy-page/es.json';
 
 export function getTranslocoModule(config: Partial<TranslocoConfig> = {}) {
   return TranslocoTestingModule.withLangs(
@@ -10,7 +12,9 @@ export function getTranslocoModule(config: Partial<TranslocoConfig> = {}) {
       en,
       es,
       'admin-page/en': admin,
-      'admin-page/es': adminSpanish
+      'admin-page/es': adminSpanish,
+      'lazy-page/en' : lazy,
+      'lazy-page/es' : lazySpanish
     },
     {
       availableLangs: ['es', 'en'],

--- a/vscode/extractor/README.md
+++ b/vscode/extractor/README.md
@@ -1,4 +1,4 @@
-# translococtx README
+# Transloco Extract
 
 ## Features
 
@@ -10,20 +10,4 @@ A context menu in VSCode editor to convert the text selection to a transloco ent
 
 This extension contributes the following settings:
 
-- `transloco.jsonrootfolder`: Glob pattern to select json translation files
-- `transloco.excludefolders`: Glob patterns to exclude json translation files
-- `transloco.selectfirstlevelobjectkeys`: Allow selection of first level object keys
-
-## Known Issues
-
-A lot
-
-## Release Notes
-
-### 0.0.1
-
-Quick and not so dirty
-
-### 0.0.4
-
-Should work better
+- `transloco.rootTranslationsPath`: Glob pattern to select json translation files


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

It does not support `multi: true` when providing TRANSLOCO_SCOPE, meaning you can only have one scope per module/component

Issue Number: N/A

## What is the new behavior?

Fix for https://github.com/ngneat/transloco/issues/181. This makes it possible to provide multiple translate scopes to a module or component. Works with structural directives and pipe.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
