### PR TITLE
refactor(common): exposed isLang and added short documentation for is…

### DIFF
--- a/projects/ngneat/transloco/src/lib/transloco.service.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.service.ts
@@ -111,6 +111,13 @@ export class TranslocoService implements OnDestroy {
     this.availableLangs = langs;
   }
 
+  /**
+   * Gets the available languages.
+   * 
+   * @returns
+   * An array of the available languages. Can be either a `string[]` or a `{ id: string; label: string }[]` 
+   * depending on how the available languages are set in your module.
+   */
   getAvailableLangs() {
     return this.availableLangs;
   }
@@ -179,7 +186,7 @@ export class TranslocoService implements OnDestroy {
       // en for example
       const langFromScope = getLangFromScope(lang);
       // en is lang
-      const hasLang = this._isLang(langFromScope);
+      const hasLang = this.isLang(langFromScope);
       // take en
       resolveLang = hasLang ? langFromScope : this.getActiveLang();
       // find the scope
@@ -376,9 +383,12 @@ export class TranslocoService implements OnDestroy {
   }
 
   /**
-   * @internal
+   * Checks if a given string is one of the specified available languages.
+   * @returns
+   * True if the given string is an available language.
+   * False if the given string is not an available language.
    */
-  _isLang(lang: string) {
+  isLang(lang: string): boolean {
     return this.getAvailableLangsIds().indexOf(lang) !== -1;
   }
 
@@ -402,7 +412,7 @@ export class TranslocoService implements OnDestroy {
    * @internal
    */
   _completeScopeWithLang(langOrScope: string) {
-    if (this._isLangScoped(langOrScope) && !this._isLang(getLangFromScope(langOrScope))) {
+    if (this._isLangScoped(langOrScope) && !this.isLang(getLangFromScope(langOrScope))) {
       return `${langOrScope}/${this.getActiveLang()}`;
     }
     return langOrScope;


### PR DESCRIPTION
…Lang and getAvailableLangs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #183 

## What is the new behavior?
Behavior is not changed. internal method `_isLang` is renamed to `isLang` and is not `@internal` anymore.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Added summary for `isLang` method and `getAvailableLangs` method.