### PR TITLE
feat(transloco): implement provideTranslocoConfig method

### DIFF
--- a/projects/ngneat/transloco/src/lib/tests/pipe/pipe-integration.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/pipe/pipe-integration.spec.ts
@@ -1,21 +1,14 @@
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 import { Component } from '@angular/core';
 import { providersMock, runLoader } from '../transloco.mocks';
-import {
-  defaultConfig,
-  TRANSLOCO_CONFIG,
-  TRANSLOCO_LANG,
-  TRANSLOCO_SCOPE,
-  TranslocoConfig,
-  TranslocoModule,
-  TranslocoService
-} from '@ngneat/transloco';
+import { defaultConfig, TRANSLOCO_LANG, TRANSLOCO_SCOPE, TranslocoModule, TranslocoService } from '@ngneat/transloco';
 import { fakeAsync } from '@angular/core/testing';
+import { provideTranslocoConfig } from '../../transloco.config';
 
-export const listenToLangChangesProvider = {
-  provide: TRANSLOCO_CONFIG,
-  useValue: { ...defaultConfig, availableLangs: ['en', 'es'], reRenderOnLangChange: true } as TranslocoConfig
-};
+export const listenToLangChangesProvider = provideTranslocoConfig({
+  availableLangs: ['en', 'es'],
+  reRenderOnLangChange: true
+});
 
 @Component({
   template: `

--- a/projects/ngneat/transloco/src/lib/tests/transloco-config-provider.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/transloco-config-provider.spec.ts
@@ -1,0 +1,36 @@
+import { provideTranslocoConfig, defaultConfig, TRANSLOCO_CONFIG, TranslocoConfig } from '../transloco.config';
+
+describe('provideTranslocoConfig', () => {
+  it('should return the expected provider with default config given no input', () => {
+    // arrange
+    const expected = {
+      provide: TRANSLOCO_CONFIG,
+      useValue: defaultConfig
+    };
+
+    // act
+    const actual = provideTranslocoConfig();
+
+    // assert
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return the expected provider with config given', () => {
+    // arrange
+    const inputConfig: TranslocoConfig = {
+      ...defaultConfig,
+      defaultLang: 'es'
+    };
+
+    const expected = {
+      provide: TRANSLOCO_CONFIG,
+      useValue: inputConfig
+    };
+
+    // act
+    const actual = provideTranslocoConfig(inputConfig);
+
+    // assert
+    expect(actual).toEqual(expected);
+  });
+});

--- a/projects/ngneat/transloco/src/lib/tests/transloco.mocks.ts
+++ b/projects/ngneat/transloco/src/lib/tests/transloco.mocks.ts
@@ -1,6 +1,6 @@
 import { DefaultTranspiler, TRANSLOCO_TRANSPILER } from '../transloco.transpiler';
 import { TRANSLOCO_LOADER } from '../transloco.loader';
-import { defaultConfig, TRANSLOCO_CONFIG, TranslocoConfig } from '../transloco.config';
+import { TRANSLOCO_CONFIG, TranslocoConfig, provideTranslocoConfig } from '../transloco.config';
 import { timer } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { DefaultHandler, TRANSLOCO_MISSING_HANDLER } from '../transloco-missing-handler';
@@ -40,11 +40,6 @@ export const loader = {
   }
 };
 
-export const configProviderMock = (config = {}) => ({
-  provide: TRANSLOCO_CONFIG,
-  useValue: { ...defaultConfig, ...config, availableLangs: ['en', 'es'] } as TranslocoConfig
-});
-
 export const loaderProviderMock = {
   provide: TRANSLOCO_LOADER,
   useValue: loader
@@ -72,7 +67,7 @@ export const fallbackStrategyProviderMock = {
 };
 
 export const providersMock = [
-  configProviderMock(),
+  provideTranslocoConfig({ availableLangs: ['en', 'es'] }),
   interceptorProviderMock,
   loaderProviderMock,
   transpilerProviderMock,

--- a/projects/ngneat/transloco/src/lib/transloco-testing.module.ts
+++ b/projects/ngneat/transloco/src/lib/transloco-testing.module.ts
@@ -3,7 +3,7 @@ import { TRANSLOCO_LOADER, TranslocoLoader } from './transloco.loader';
 import { HashMap, Translation } from './types';
 import { Observable, of } from 'rxjs';
 import { defaultProviders, TranslocoModule } from './transloco.module';
-import { TRANSLOCO_CONFIG, TranslocoConfig } from './transloco.config';
+import { TranslocoConfig, provideTranslocoConfig } from './transloco.config';
 
 export class TestingLoader implements TranslocoLoader {
   constructor(@Inject('translocoLangs') private langs: HashMap<Translation>) {}
@@ -30,14 +30,11 @@ export class TranslocoTestingModule {
           useClass: TestingLoader
         },
         defaultProviders,
-        {
-          provide: TRANSLOCO_CONFIG,
-          useValue: {
-            prodMode: true,
-            missingHandler: { logMissingKey: false },
-            ...config
-          }
-        }
+        provideTranslocoConfig({
+          prodMode: true,
+          missingHandler: { logMissingKey: false },
+          ...config
+        })
       ]
     };
   }

--- a/projects/ngneat/transloco/src/lib/transloco.config.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.config.ts
@@ -42,3 +42,17 @@ export const defaultConfig: TranslocoConfig = {
     aot: false
   }
 };
+
+/**
+ * Sets up TRANSLOCO_CONFIG provider
+ *
+ * @param config The partial config object to load, this is optional,
+ * will be spread after defaultConfig.
+ * @returns TRANSLOCO_CONFIG Provider given the optional config parameter.
+ */
+export function provideTranslocoConfig(config: Partial<TranslocoConfig> = defaultConfig) {
+  return {
+    provide: TRANSLOCO_CONFIG,
+    useValue: { ...defaultConfig, ...config }
+  };
+}

--- a/projects/ngneat/transloco/src/public-api.ts
+++ b/projects/ngneat/transloco/src/public-api.ts
@@ -3,7 +3,7 @@ export { TranslocoDirective } from './lib/transloco.directive';
 export { TranslocoPipe } from './lib/transloco.pipe';
 export { TranslocoModule, defaultProviders } from './lib/transloco.module';
 export { TRANSLOCO_LOADER, TranslocoLoader } from './lib/transloco.loader';
-export { TranslocoConfig, TRANSLOCO_CONFIG, defaultConfig } from './lib/transloco.config';
+export { TranslocoConfig, TRANSLOCO_CONFIG, defaultConfig, provideTranslocoConfig } from './lib/transloco.config';
 export { TRANSLOCO_TRANSPILER, DefaultTranspiler, TranslocoTranspiler } from './lib/transloco.transpiler';
 export { Translation, FailedEvent, HashMap, LoadedEvent, TranslocoEvents } from './lib/types';
 export { TRANSLOCO_SCOPE } from './lib/transloco-scope';
@@ -20,7 +20,7 @@ export {
 export {
   TRANSLOCO_MISSING_HANDLER,
   TranslocoMissingHandler,
-  TranslocoMissingHandlerData,
+  TranslocoMissingHandlerData
 } from './lib/transloco-missing-handler';
 export { getBrowserCultureLang, getBrowserLang } from './lib/browser-lang';
 export * from './lib/types';

--- a/schematics/src/ng-add/index.ts
+++ b/schematics/src/ng-add/index.ts
@@ -138,14 +138,11 @@ export default function(options: SchemaOptions): Rule {
     options.module = findRootModule(host, options.module, sourceRoot) as string;
     const modulePath = options.module.substring(0, options.module.lastIndexOf('/') + 1);
     const prodMode = isLib ? 'false' : 'environment.production';
-    const configProviderTemplate = `{
-      provide: TRANSLOCO_CONFIG,
-      useValue: {
-        availableLangs: [${stringifyList(langs)}],
-        defaultLang: '${langs[0]}',
-        prodMode: ${prodMode},
-      } as TranslocoConfig
-    }`;
+    const configProviderTemplate = `provideTranslocoConfig({
+      availableLangs: [${stringifyList(langs)}],
+      defaultLang: '${langs[0]}',
+      prodMode: ${prodMode},
+    })`;
 
     if (options.ssr) {
       updateEnvironmentBaseUrl(host, sourceRoot, 'http://localhost:4200');
@@ -164,7 +161,7 @@ export default function(options: SchemaOptions): Rule {
       mergeWith(getLoaderTemplates(options, modulePath)),
       isLib ? noop() : addImportsToModuleFile(options, ['environment'], '../environments/environment'),
       addImportsToModuleFile(options, ['translocoLoader'], './transloco.loader'),
-      addImportsToModuleFile(options, ['TranslocoModule', 'TRANSLOCO_CONFIG', 'TranslocoConfig']),
+      addImportsToModuleFile(options, ['TranslocoModule', 'TranslocoConfig', 'provideTranslocoConfig']),
       addImportsToModuleDeclaration(options, ['TranslocoModule']),
       addProvidersToModuleDeclaration(options, [configProviderTemplate, 'translocoLoader'])
     ])(host, context);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { TranslocoLocaleModule } from '@ngneat/transloco-locale';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { TRANSLOCO_CONFIG, TranslocoConfig, TranslocoModule } from '@ngneat/transloco';
+import { TranslocoModule, provideTranslocoConfig } from '@ngneat/transloco';
 import { HttpClientModule } from '@angular/common/http';
 import { HomeComponent } from './home/home.component';
 import { OnPushComponent } from './on-push/on-push.component';
@@ -43,19 +43,16 @@ import { TranslocoMessageFormatModule } from '@ngneat/transloco-messageformat';
   ],
   providers: [
     httpLoader,
-    {
-      provide: TRANSLOCO_CONFIG,
-      useValue: {
-        prodMode: environment.production,
-        availableLangs: [{ id: 'en', label: 'English' }, { id: 'es', label: 'Spanish' }],
-        reRenderOnLangChange: true,
-        fallbackLang: 'es',
-        defaultLang: 'en',
-        missingHandler: {
-          useFallbackTranslation: false
-        }
-      } as TranslocoConfig
-    }
+    provideTranslocoConfig({
+      prodMode: environment.production,
+      availableLangs: [{ id: 'en', label: 'English' }, { id: 'es', label: 'Spanish' }],
+      reRenderOnLangChange: true,
+      fallbackLang: 'es',
+      defaultLang: 'en',
+      missingHandler: {
+        useFallbackTranslation: false
+      }
+    })
   ],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
Closes #195

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #195

## What is the new behavior?

Adds new `provideTranslocoConfig` method as described in the issue.

This method can be used to provide the `TRANSLOCO_CONFIG` provider to the `providers` array. For example:
```
providers: [
    httpLoader,
    provideTranslocoConfig({
      prodMode: environment.production,
      availableLangs: [{ id: 'en', label: 'English' }, { id: 'es', label: 'Spanish' }],
      reRenderOnLangChange: true,
      fallbackLang: 'es',
      defaultLang: 'en',
      missingHandler: {
        useFallbackTranslation: false
      }
    })
  ],
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
