### PR TITLE
chore: 🤖 remove { providedIn: 'root' } from loader template

### DIFF
--- a/schematics/src/ng-add/files/transloco-module/transloco-root.module.__ts__
+++ b/schematics/src/ng-add/files/transloco-module/transloco-root.module.__ts__
@@ -10,7 +10,7 @@ import {
 import { Injectable, NgModule } from '@angular/core';
 <% if (importEnv) {%>import { environment } from '../environments/environment';<% } %>
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class TranslocoHttpLoader implements TranslocoLoader {
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
The loader is provided in AppModule using the TRANSLOCO_LOADER Injection Token. It is unnecessary to also have `{ providedIn: 'root' }` in the loader's Injectable decorator.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: update schematic template
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
