### PR TITLE
feat(transloco-scoped-libs): adds modifyGitignore option

### DIFF
--- a/projects/ngneat/transloco-scoped-libs/cli.js
+++ b/projects/ngneat/transloco-scoped-libs/cli.js
@@ -4,12 +4,16 @@ const translocoUtils = require('@ngneat/transloco-utils');
 const { run } = require('./index');
 const commandLineArgs = require('command-line-args');
 
-const optionDefinitions = [{ name: 'watch', alias: 'w', type: Boolean, defaultValue: false }];
+const optionDefinitions = [
+  { name: 'watch', alias: 'w', type: Boolean, defaultValue: false },
+  { name: 'modifyGitignore', alias: 'm', type: Boolean, defaultValue: true }
+];
 const cliParams = commandLineArgs(optionDefinitions);
 const config = translocoUtils.getConfig();
 
 run({
   watch: cliParams.watch,
+  modifyGitignore: cliParams.modifyGitignore,
   rootTranslationsPath: config.rootTranslationsPath,
   scopedLibs: config.scopedLibs
 });


### PR DESCRIPTION
Adds an option to the transloco-scoped-libs that allows not to modify the .gitignore file at all

resolves #216

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

https://github.com/ngneat/transloco/issues/216

Issue Number: 216

## What is the new behavior?

A new option to the transloco-scoped-libs tool has been added. Setting it to true results in not modifying gitignore file at all

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
