### PR TITLE
feat(directive): add ability to get full nested object

### DIFF
--- a/projects/ngneat/transloco/src/lib/tests/directive/structural.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/directive/structural.spec.ts
@@ -15,6 +15,7 @@ describe('Structural directive', () => {
            <span>{{t('fromList')}}</span>
            <p>{{t('a.b.c')}}</p>
            <h2>{{t('a.b.c', {fromList: "value"}) }}</h2>
+           <a>{{t('nested', true) | json }}</a>
         </section>
      `);
     runLoader();
@@ -24,6 +25,9 @@ describe('Structural directive', () => {
     expect(spectator.queryHost('span')).toHaveText('from list');
     expect(spectator.queryHost('p')).toHaveText('a.b.c from list english');
     expect(spectator.queryHost('h2')).toHaveText('a.b.c value english');
+    expect(spectator.queryHost('a')).toHaveText(
+      JSON.stringify({ desc: 'Desc english', title: 'Title english' }, null, 2)
+    );
   }));
 
   it('should set the translation value and listen to lang changes', fakeAsync(() => {
@@ -34,6 +38,7 @@ describe('Structural directive', () => {
            <span>{{t('fromList')}}</span>
            <p>{{t('a.b.c')}}</p>
            <h2>{{t('a.b.c', {fromList: "value"}) }}</h2>
+           <a>{{t('nested', true) | json }}</a>
         </section>
      `,
       { detectChanges: false }
@@ -48,6 +53,9 @@ describe('Structural directive', () => {
     expect(spectator.queryHost('span')).toHaveText('from list');
     expect(spectator.queryHost('p')).toHaveText('a.b.c from list english');
     expect(spectator.queryHost('h2')).toHaveText('a.b.c value english');
+    expect(spectator.queryHost('a')).toHaveText(
+      JSON.stringify({ desc: 'Desc english', title: 'Title english' }, null, 2)
+    );
     (service as TranslocoService).setActiveLang('es');
     runLoader();
     spectator.detectChanges();
@@ -55,6 +63,9 @@ describe('Structural directive', () => {
     expect(spectator.queryHost('span')).toHaveText('from list');
     expect(spectator.queryHost('p')).toHaveText('a.b.c from list spanish');
     expect(spectator.queryHost('h2')).toHaveText('a.b.c value spanish');
+    expect(spectator.queryHost('a')).toHaveText(
+      JSON.stringify({ desc: 'Desc spanish', title: 'Title spanish' }, null, 2)
+    );
   }));
 
   it('should create embedded view once', fakeAsync(() => {

--- a/projects/ngneat/transloco/src/lib/transloco.directive.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.directive.ts
@@ -118,17 +118,22 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
   }
 
   private getTranslateFn(lang: string, read: string | undefined): (key: string, params?: HashMap) => any {
-    return (key: string, params: HashMap) => {
+    return (key: string, params: HashMap | boolean, asObject = false) => {
       const withRead = read ? `${read}.${key}` : key;
-      const withParams = params ? `${withRead}${JSON.stringify(params)}` : withRead;
+      let withParams = withRead;
+      let isObject = asObject || (typeof params === 'boolean' && params);
+      if (typeof params === 'object' && params !== null) {
+        withParams = `${withRead}${JSON.stringify(params)}`;
+      }
       if (this.translationMemo.hasOwnProperty(withParams)) {
         return this.translationMemo[withParams].value;
       }
       this.translationMemo[withParams] = {
-        params,
-        value: this.translocoService.translate(withRead, params, lang)
+        params: params as HashMap,
+        value: isObject
+          ? this.translocoService.translateObject(withRead, params as HashMap, lang)
+          : this.translocoService.translate(withRead, params as HashMap, lang)
       };
-
       return this.translationMemo[withParams].value;
     };
   }

--- a/src/app/on-push/on-push.component.html
+++ b/src/app/on-push/on-push.component.html
@@ -4,6 +4,7 @@
     <li class="list-group-item" data-cy="regular"><b>Regular: </b>{{ t('home') }}</li>
     <li class="list-group-item" data-cy="with-params"><b>With params: </b>{{ t('alert', { value: dynamic }) }}</li>
     <li class="list-group-item" data-cy="with-translation-reuse"><b>With translation reuse: </b> {{ t('a.b.c') }}</li>
+    <li class="list-group-item" data-cy="object"><b>Object: </b>{{ t('nested', true) | json }}</li>
   </ul>
 </ng-container>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

This PR is similar to this one (https://github.com/ngneat/transloco/pull/44) but the difference is that we can retrieve the full nested object.

You can imagine: 
> "Why I need the reference of object?"

And I answer:
> "Because we can use smart/dumb components pattern and need the parent to control the translations of your childs, making then more unbound"

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [221](https://github.com/ngneat/transloco/issues/221)

## What is the new behavior?

As described in the issue, the objective is to support the return of new objects by adding in the value `true` in the second parameter or, if you need to pass information in the second parameter (parameterized translation), put in the third parameter, the value `true`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

1. maybe we can pass more properties and add a way that we pass an object (instead multiple parameters) to control the behavior of translation