### PR TITLE
fix(messageformat): forRoot convention for the messageformat module

### DIFF
--- a/projects/ngneat/transloco-messageformat/README.md
+++ b/projects/ngneat/transloco-messageformat/README.md
@@ -35,7 +35,7 @@ import { TranslocoMessageFormatModule } from '@ngneat/transloco-messageformat';
 @NgModule({
   imports: [
     ...,
-    TranslocoMessageFormatModule.init()
+    TranslocoMessageFormatModule.forRoot()
   ]
 })
 
@@ -49,7 +49,7 @@ By default, messageformat initializes _all_ locales. You could also provide the 
 @NgModule({
   imports: [
     ...,
-    TranslocoMessageFormatModule.init(
+    TranslocoMessageFormatModule.forRoot(
       {
         locales: 'en-GB'
       }
@@ -71,7 +71,7 @@ This is how you would enable bi-directional support and add a custom formatter, 
 @NgModule({
   imports: [
     ...,
-    TranslocoMessageFormatModule.init(
+    TranslocoMessageFormatModule.forRoot(
       {
         biDiSupport: true,
         customFormatters: { upcase: v => v.toUpperCase() }

--- a/projects/ngneat/transloco-messageformat/src/lib/messageformat.module.ts
+++ b/projects/ngneat/transloco-messageformat/src/lib/messageformat.module.ts
@@ -3,10 +3,19 @@ import { TRANSLOCO_TRANSPILER } from '@ngneat/transloco';
 import { MessageFormatTranspiler } from './messageformat.transpiler';
 import { TRANSLOCO_MESSAGE_FORMAT_CONFIG, MessageformatConfig } from './messageformat.config';
 
-
+/**
+ * Transloco message format module
+ * 
+ * Adds support for ICU syntax translation using `messageformat.js`.
+ */
 @NgModule()
 export class TranslocoMessageFormatModule {
-  static init(config?: MessageformatConfig): ModuleWithProviders {
+  /**
+   * Get a module that can be imported in the root application module
+   * @param config Module configuration
+   * @return Module
+   */
+  static forRoot(config?: MessageformatConfig): ModuleWithProviders {
     return {
       ngModule: TranslocoMessageFormatModule,
       providers: [
@@ -18,6 +27,14 @@ export class TranslocoMessageFormatModule {
       ]
     };
   }
-
+  /**
+   * Get a module that can be imported in the root application module
+   * @param config Module configuration
+   * @return Module
+   * @deprecated Use `forRoot()` instead
+   */
+  static init(config?: MessageformatConfig): ModuleWithProviders {
+    return TranslocoMessageFormatModule.forRoot(config);
+  }
   constructor() {}
 }


### PR DESCRIPTION
Replaces and deprecates the `init` module method with a more
conventional `forRoot` method.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When importing the message format module, an `init` static method is called, unlike most common Angular modules that provide a `forRoot` (and sometimes `forChild` or `forFeature`).

Issue Number: N/A

## What is the new behavior?

`forRoot` called instead of `init` when importing the module.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

The `forRoot` method has to be called instead of `init`. However the `init` method is still available and has been flagged as deprecated.

## Other information
