### PR TITLE
plugin(angular9): fix issue with transloco-locale and angular 9

### DIFF
--- a/libs/transloco-locale/src/lib/pipes/transloco-currency.pipe.ts
+++ b/libs/transloco-locale/src/lib/pipes/transloco-currency.pipe.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Inject, Pipe, PipeTransform } from '@angular/core';
+import { ChangeDetectorRef, Inject, OnDestroy, Pipe, PipeTransform } from '@angular/core';
 import { isNil } from '@ngneat/transloco';
 import { getDefaultOptions } from '../shared';
 import { LOCALE_CONFIG, LocaleConfig } from '../transloco-locale.config';
@@ -10,7 +10,7 @@ import { TranslocoLocalePipe } from './transloco-locale.pipe';
   name: 'translocoCurrency',
   pure: false
 })
-export class TranslocoCurrencyPipe extends TranslocoLocalePipe implements PipeTransform {
+export class TranslocoCurrencyPipe extends TranslocoLocalePipe implements PipeTransform, OnDestroy {
   constructor(
     protected translocoLocaleService: TranslocoLocaleService,
     protected cdr: ChangeDetectorRef,
@@ -46,5 +46,9 @@ export class TranslocoCurrencyPipe extends TranslocoLocalePipe implements PipeTr
       currency: currencyCode || this.translocoLocaleService._resolveCurrencyCode()
     };
     return this.translocoLocaleService.localizeNumber(value, 'currency', locale, options);
+  }
+
+  ngOnDestroy(): void {
+    this.onDestroy();
   }
 }

--- a/libs/transloco-locale/src/lib/pipes/transloco-date.pipe.ts
+++ b/libs/transloco-locale/src/lib/pipes/transloco-date.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, ChangeDetectorRef, PipeTransform, Inject } from '@angular/core';
+import { Pipe, ChangeDetectorRef, PipeTransform, Inject, OnDestroy } from '@angular/core';
 import { isNil } from '@ngneat/transloco';
 import { toDate } from '../helpers';
 import { getDefaultOptions } from '../shared';
@@ -11,7 +11,7 @@ import { TranslocoLocalePipe } from './transloco-locale.pipe';
   name: 'translocoDate',
   pure: false
 })
-export class TranslocoDatePipe extends TranslocoLocalePipe implements PipeTransform {
+export class TranslocoDatePipe extends TranslocoLocalePipe implements PipeTransform, OnDestroy {
   constructor(
     protected translocoLocaleService: TranslocoLocaleService,
     protected cdr: ChangeDetectorRef,
@@ -42,5 +42,9 @@ export class TranslocoDatePipe extends TranslocoLocalePipe implements PipeTransf
       ...getDefaultOptions(locale, 'date', this.localeConfig),
       ...options
     });
+  }
+
+  ngOnDestroy(): void {
+    this.onDestroy();
   }
 }

--- a/libs/transloco-locale/src/lib/pipes/transloco-decimal.pipe.ts
+++ b/libs/transloco-locale/src/lib/pipes/transloco-decimal.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform, ChangeDetectorRef, Inject } from '@angular/core';
+import { Pipe, PipeTransform, ChangeDetectorRef, Inject, OnDestroy } from '@angular/core';
 import { isNil } from '@ngneat/transloco';
 import { getDefaultOptions } from '../shared';
 import { LOCALE_CONFIG, LocaleConfig } from '../transloco-locale.config';
@@ -10,7 +10,7 @@ import { TranslocoLocalePipe } from './transloco-locale.pipe';
   name: 'translocoDecimal',
   pure: false
 })
-export class TranslocoDecimalPipe extends TranslocoLocalePipe implements PipeTransform {
+export class TranslocoDecimalPipe extends TranslocoLocalePipe implements PipeTransform, OnDestroy {
   constructor(
     protected translocoLocaleService: TranslocoLocaleService,
     protected cdr: ChangeDetectorRef,
@@ -37,5 +37,9 @@ export class TranslocoDecimalPipe extends TranslocoLocalePipe implements PipeTra
       ...numberFormatOptions
     };
     return this.translocoLocaleService.localizeNumber(value, 'decimal', locale, options);
+  }
+
+  ngOnDestroy(): void {
+    this.onDestroy();
   }
 }

--- a/libs/transloco-locale/src/lib/pipes/transloco-locale.pipe.ts
+++ b/libs/transloco-locale/src/lib/pipes/transloco-locale.pipe.ts
@@ -1,9 +1,9 @@
-import { ChangeDetectorRef, OnDestroy } from '@angular/core';
+import { ChangeDetectorRef } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TranslocoLocaleService } from '../transloco-locale.service';
 import { Locale } from '../../lib/transloco-locale.types';
 
-export class TranslocoLocalePipe implements OnDestroy {
+export class TranslocoLocalePipe {
   private subscription: Subscription;
 
   constructor(protected translocoLocaleService: TranslocoLocaleService, protected cdr: ChangeDetectorRef) {
@@ -16,7 +16,7 @@ export class TranslocoLocalePipe implements OnDestroy {
     return locale || this.translocoLocaleService.getLocale();
   }
 
-  ngOnDestroy(): void {
+  protected onDestroy(): void {
     this.subscription.unsubscribe();
   }
 }

--- a/libs/transloco-locale/src/lib/pipes/transloco-percent.pipe.ts
+++ b/libs/transloco-locale/src/lib/pipes/transloco-percent.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform, ChangeDetectorRef, Inject } from '@angular/core';
+import { Pipe, PipeTransform, ChangeDetectorRef, Inject, OnDestroy } from '@angular/core';
 import { isNil } from '@ngneat/transloco';
 import { getDefaultOptions } from '../shared';
 import { LOCALE_CONFIG, LocaleConfig } from '../transloco-locale.config';
@@ -10,7 +10,7 @@ import { TranslocoLocalePipe } from './transloco-locale.pipe';
   name: 'translocoPercent',
   pure: false
 })
-export class TranslocoPercentPipe extends TranslocoLocalePipe implements PipeTransform {
+export class TranslocoPercentPipe extends TranslocoLocalePipe implements PipeTransform, OnDestroy {
   constructor(
     protected translocoLocaleService: TranslocoLocaleService,
     protected cdr: ChangeDetectorRef,
@@ -37,5 +37,9 @@ export class TranslocoPercentPipe extends TranslocoLocalePipe implements PipeTra
       ...numberFormatOptions
     };
     return this.translocoLocaleService.localizeNumber(value, 'percent', locale, options);
+  }
+
+  ngOnDestroy(): void {
+    this.onDestroy();
   }
 }


### PR DESCRIPTION
moved angular feature (onDestroy) down to children classes

see https://angular.io/guide/migration-undecorated-classes#im-a-library-author-should-i-add-the-directive-decorator-to-base-classes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Upgrading to angular 9 causes issues with transloco-locale when running tests or in jit mode.

```
 Error: Directive TranslocoCurrencyPipe has no selector, please add it!
        Directive TranslocoDatePipe has no selector, please add it!
        Directive TranslocoDecimalPipe has no selector, please add it!
        Directive TranslocoPercentPipe has no selector, please add it!
```

The problem seems to be caused by the fact that the transloco-locale pipes are using a base class that uses an angular feature (onDestroy). According to the angular doc, with Ivy, base classes should now be annotated as well. On option to avoid adding the empty `@Directive()` annotation which could possibly break older versions of angular is to push down the angular features to children.

See https://angular.io/guide/migration-undecorated-classes#im-a-library-author-should-i-add-the-directive-decorator-to-base-classes

Issue Number: N/A

## What is the new behavior?

No error when running tests.

Tested locally on an angular 9 project.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
