### PR TITLE
fix: exclude prefixedTranslateModule when migrating

### DIFF
--- a/schematics/src/migrate/ngx-translate-migration.ts
+++ b/schematics/src/migrate/ngx-translate-migration.ts
@@ -40,7 +40,7 @@ export function run(path) {
 
   const modules = {
     files: `${path}.ts`,
-    from: /TranslateModule(?![^]*from)(\.(forRoot|forChild)\(({[^}]*})*[^)]*\))?/g,
+    from: /(?<![a-zA-Z])TranslateModule(?![^]*from)(\.(forRoot|forChild)\(({[^}]*})*[^)]*\))?/g,
     to: 'TranslocoModule'
   };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features) - (no migration tests)
- [ ] Docs have been added / updated (for bug fixes / features) - (no documentation change needed)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
If there is a module called `AbTranslateModule`, it currently gets replaced with `AbTranslocoModule`. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
This change modifies the regex so that it doesn't match "TranslateModule" if it's preceded by any letter character.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
You can see the updated regex and a few tests here:
https://regexr.com/530id

This is important for our use-case because we want to use the migration to migrate pipes and other things, but we don't want it to pick up the `AbTranslateModule` that consumers may have.