### PR TITLE
fix: 🐛 don't display loading template if translations were load

### DIFF
--- a/projects/ngneat/transloco/src/lib/tests/directive/shared.ts
+++ b/projects/ngneat/transloco/src/lib/tests/directive/shared.ts
@@ -21,8 +21,7 @@ function initScopeTest(host: SpectatorHost<TranslocoDirective, HostComponent>, s
 export function testMergedScopedTranslation(spectator: SpectatorHost<TranslocoDirective>, preload?: boolean) {
   const service = spectator.get(TranslocoService);
   if (preload) {
-    service.load('en').subscribe();
-    runLoader();
+    preloadTranslations(spectator);
   }
   initScopeTest(spectator, service);
   expect(spectator.queryHost('.global')).toHaveText(preload ? 'home english' : '');
@@ -56,4 +55,10 @@ export function testTranslationWithRead(spectator: SpectatorHost<TranslocoDirect
   runLoader();
   spectator.detectChanges();
   expect(spectator.queryHost('div')).toHaveText('Title spanish');
+}
+
+export function preloadTranslations(spectator: SpectatorHost<TranslocoDirective>, lang = 'en') {
+  const service = spectator.get(TranslocoService);
+  service.load(lang).subscribe();
+  runLoader();
 }

--- a/projects/ngneat/transloco/src/lib/tests/directive/structural-loading-tpl.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/directive/structural-loading-tpl.spec.ts
@@ -2,7 +2,7 @@ import { fakeAsync } from '@angular/core/testing';
 import { TemplateHandler, TranslocoDirective } from '@ngneat/transloco';
 import { loadingTemplateMock, providersMock, runLoader } from '../transloco.mocks';
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
-import { createFactory } from './shared';
+import { createFactory, preloadTranslations } from './shared';
 import { TranslocoLoaderComponent } from '../../loader-component.component';
 
 describe('Loading Template', () => {
@@ -40,6 +40,25 @@ describe('Loading Template', () => {
 
     expect((TemplateHandler.prototype as any).attachView).not.toHaveBeenCalled();
   });
+
+  it('should not attachView if the translation have already loaded', fakeAsync(() => {
+    spyOn<TemplateHandler>(TemplateHandler.prototype, 'attachView').and.callThrough();
+    spectator = createHost(
+      `
+        <section *transloco="let t; scope: 'lazy-page'; loadingTpl: loading">
+          <h1 data-cy="lazy-page">{{ t('title') }}</h1>
+        </section>
+
+        <ng-template #loading>
+          <h1 id="lazy-page-loading">Loading...</h1>
+        </ng-template>
+      `,
+      { detectChanges: false }
+    );
+    preloadTranslations(spectator);
+
+    expect((TemplateHandler.prototype as any).attachView).not.toHaveBeenCalled();
+  }));
 });
 
 describe('Custom loading template', () => {

--- a/projects/ngneat/transloco/src/lib/transloco.directive.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.directive.ts
@@ -60,12 +60,6 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
   ) {}
 
   ngOnInit() {
-    const loadingTpl = this.getLoadingTpl();
-    if (loadingTpl) {
-      this.loaderTplHandler = new TemplateHandler(loadingTpl, this.vcr);
-      this.loaderTplHandler.attachView();
-    }
-
     const listenToLangChange = shouldListenToLangChanges(this.translocoService, this.providerLang || this.inlineLang);
 
     this.subscription = this.translocoService.langChanges$
@@ -77,8 +71,10 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
             active: activeLang
           });
 
-          return Array.isArray(this.providerScope) ?
-            forkJoin((<TranslocoScope[]>this.providerScope).map(providerScope => this.resolveScope(lang, providerScope)))
+          return Array.isArray(this.providerScope)
+            ? forkJoin(
+                (<TranslocoScope[]>this.providerScope).map(providerScope => this.resolveScope(lang, providerScope))
+              )
             : this.resolveScope(lang, this.providerScope);
         }),
         listenOrNotOperator(listenToLangChange)
@@ -89,6 +85,12 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
         this.cdr.markForCheck();
         this.initialized = true;
       });
+
+    const loadingTpl = this.getLoadingTpl();
+    if (!this.initialized && loadingTpl) {
+      this.loaderTplHandler = new TemplateHandler(loadingTpl, this.vcr);
+      this.loaderTplHandler.attachView();
+    }
   }
 
   ngOnChanges(changes) {


### PR DESCRIPTION
close #264