### PR TITLE
fix: 🐛 Put transloco.module in its own folder

### DIFF
--- a/schematics/src/ng-add/files/transloco-module/transloco-root.module.__ts__
+++ b/schematics/src/ng-add/files/transloco-module/transloco-root.module.__ts__
@@ -8,7 +8,7 @@ import {
   TranslocoModule
 } from '@ngneat/transloco';
 import { Injectable, NgModule } from '@angular/core';
-<% if (importEnv) {%>import { environment } from '../environments/environment';<% } %>
+<% if (importEnv) {%>import { environment } from '../../environments/environment';<% } %>
 
 @Injectable({ providedIn: 'root' })
 export class TranslocoHttpLoader implements TranslocoLoader {

--- a/schematics/src/ng-add/index.ts
+++ b/schematics/src/ng-add/index.ts
@@ -24,7 +24,7 @@ import { findRootModule } from '../utils/find-module';
 import { getProject, setEnvironments } from '../utils/projects';
 import { checkIfTranslationFilesExist } from '../utils/translations';
 import { createConfig } from '../utils/transloco';
-import {SchemaOptions, Loaders} from './schema';
+import { SchemaOptions, Loaders } from './schema';
 
 function jsonTranslationFileCreator(source, lang) {
   return source.create(
@@ -101,7 +101,7 @@ function createTranslocoModule(isLib: boolean, ssr: boolean, langs: string[], pa
       loaderPrefix: ssr ? '${environment.baseUrl}' : '',
       prodMode: isLib ? 'false' : 'environment.production'
     }),
-    move('/', path)
+    move('/transloco/', path)
   ]);
 }
 
@@ -138,9 +138,9 @@ export default function(options: SchemaOptions): Rule {
     return chain([
       options.loader === Loaders.Http
         ? chain([
-          addImportsToModuleFile(options, ['HttpClientModule'], '@angular/common/http'),
-          addImportsToModuleDeclaration(options, ['HttpClientModule'])
-        ])
+            addImportsToModuleFile(options, ['HttpClientModule'], '@angular/common/http'),
+            addImportsToModuleDeclaration(options, ['HttpClientModule'])
+          ])
         : noop(),
       checkIfTranslationFilesExist(assetsPath, langs, '.json', true) ? noop() : mergeWith(translateFiles),
       mergeWith(createTranslocoModule(isLib, options.ssr, langs, modulePath)),

--- a/schematics/src/ng-add/index.ts
+++ b/schematics/src/ng-add/index.ts
@@ -101,7 +101,7 @@ function createTranslocoModule(isLib: boolean, ssr: boolean, langs: string[], pa
       loaderPrefix: ssr ? '${environment.baseUrl}' : '',
       prodMode: isLib ? 'false' : 'environment.production'
     }),
-    move('/transloco/', path)
+    move('/', path)
   ]);
 }
 
@@ -127,7 +127,7 @@ export default function(options: SchemaOptions): Rule {
     const translateFiles = apply(source(createTranslateFiles(langs, translationCreator)), [move('/', assetsPath)]);
 
     options.module = findRootModule(host, options.module, sourceRoot) as string;
-    const modulePath = options.module.substring(0, options.module.lastIndexOf('/') + 1);
+    const modulePath = options.module.substring(0, options.module.lastIndexOf('/') + 1) + 'transloco/';
 
     if (options.ssr) {
       updateEnvironmentBaseUrl(host, sourceRoot, 'http://localhost:4200');

--- a/schematics/src/ng-add/index.ts
+++ b/schematics/src/ng-add/index.ts
@@ -144,7 +144,7 @@ export default function(options: SchemaOptions): Rule {
         : noop(),
       checkIfTranslationFilesExist(assetsPath, langs, '.json', true) ? noop() : mergeWith(translateFiles),
       mergeWith(createTranslocoModule(isLib, options.ssr, langs, modulePath)),
-      addImportsToModuleFile(options, ['TranslocoRootModule'], './transloco-root.module'),
+      addImportsToModuleFile(options, ['TranslocoRootModule'], './transloco/transloco-root.module'),
       addImportsToModuleDeclaration(options, ['TranslocoRootModule'])
     ])(host, context);
   };


### PR DESCRIPTION
Prevent Angular CLI generator from asking module name when generating
items by putting transloco.module in its own folder

Closes: #318

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
