### PR TITLE
fix: 🐛 update schematic for keys-manager

### DIFF
--- a/schematics/src/schematics.consts.ts
+++ b/schematics/src/schematics.consts.ts
@@ -2,3 +2,5 @@ export const PROJECT_NAME = 'transloco';
 export const NPM_SCOPE = '@ngneat';
 export const LIB_NAME = '@ngneat/transloco';
 export const CONFIG_FILE = 'transloco.config.js';
+export const KEYS_MANAGER_VERSION = '2.2.1';
+export const NGX_BUILD_PLUS_VERSION = '10.1.1';


### PR DESCRIPTION
Changes the schematic for keys-manager to use angular-defined package managers. Versions of the package to install are stored as constants. Fixes: #317 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently `ng g @ngneat/transloco:keys-manager` will forcibly use npm to install packages even though the user may be using a different package manager.

Issue Number: N/A

## What is the new behavior?

The schematic will use built in functions to the schematics library to install the packages. Further to that `ngx-build-plus` was being installed regardless of if the user selected `CLI` in the initial options. This was refactored into the same conditional used for `Webpack` and `Both`. The only notable change is that this requires the package version of `@ngneat/transloco-keys-manager` and `ngx-build-plus` to be kept up to date in `schematics/src/schematics.consts.ts`


## Does this PR introduce a breaking change?


- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Some other minor refactoring was performed by adding types to some function parameters that were missing them in that schematic.

This schematic was tested on my local machine on an Angular 10 project, and worked fine. 
