### PR TITLE
plugin (locale): Error when usingDatePipe in Firefox 79 with timeStyle

### DIFF
--- a/projects/ngneat/transloco-locale/src/lib/helpers.ts
+++ b/projects/ngneat/transloco-locale/src/lib/helpers.ts
@@ -21,7 +21,7 @@ export function localizeNumber(value: number | string, locale: Locale, options: 
 
 export function localizeDate(date: Date, locale: Locale, options: DateFormatOptions): string {
   if (isDate(date)) {
-    return date.toLocaleDateString(locale, options);
+    return new Intl.DateTimeFormat(locale, options).format(date);
   }
   return '';
 }

--- a/projects/ngneat/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
+++ b/projects/ngneat/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
@@ -11,7 +11,6 @@ describe('TranslocoDatePipe', () => {
     service = createFakeService();
     cdr = createFakeCDR();
     date = new Date(2019, 9, 7, 12, 0, 0);
-    spyOn(date, 'toLocaleDateString').and.callThrough();
   });
 
   it('should transform date to locale formatted date', () => {
@@ -20,28 +19,46 @@ describe('TranslocoDatePipe', () => {
   });
 
   it('should consider a given format over the current locale', () => {
+    spyOn(Intl, 'DateTimeFormat').and.callThrough();
     const pipe = new TranslocoDatePipe(service, cdr, defaultConfig.localeConfig);
     pipe.transform(date, { dateStyle: 'medium', timeStyle: 'medium' });
-    expect(date.toLocaleDateString).toHaveBeenCalledWith('en-US', { dateStyle: 'medium', timeStyle: 'medium' });
+    const call = (Intl.DateTimeFormat as any).calls.argsFor(0);
+
+    expect(call[1].dateStyle).toEqual('medium');
+    expect(call[1].timeStyle).toEqual('medium');
   });
 
   it('should consider a global date config', () => {
+    spyOn(Intl, 'DateTimeFormat').and.callThrough();
     const pipe = new TranslocoDatePipe(service, cdr, LOCALE_CONFIG_MOCK);
     pipe.transform(date);
-    expect(date.toLocaleDateString).toHaveBeenCalledWith('en-US', { dateStyle: 'medium', timeStyle: 'medium' });
+    const call = (Intl.DateTimeFormat as any).calls.argsFor(0);
+
+    expect(call[1].dateStyle).toEqual('medium');
+    expect(call[1].timeStyle).toEqual('medium');
   });
 
   it('should consider a locale config over global', () => {
+    spyOn(Intl, 'DateTimeFormat').and.callThrough();
     service = createFakeService('es-ES');
     const pipe = new TranslocoDatePipe(service, cdr, LOCALE_CONFIG_MOCK);
     pipe.transform(date);
-    expect(date.toLocaleDateString).toHaveBeenCalledWith('es-ES', { dateStyle: 'long', timeStyle: 'long' });
+
+    const call = (Intl.DateTimeFormat as any).calls.argsFor(0);
+
+    expect(call[0]).toEqual('es-ES');
+    expect(call[1].dateStyle).toEqual('long');
+    expect(call[1].timeStyle).toEqual('long');
   });
 
   it('should consider a given config over the global config', () => {
+    spyOn(Intl, 'DateTimeFormat').and.callThrough();
     const pipe = new TranslocoDatePipe(service, cdr, LOCALE_CONFIG_MOCK);
     pipe.transform(date, { dateStyle: 'full' });
-    expect(date.toLocaleDateString).toHaveBeenCalledWith('en-US', { dateStyle: 'full', timeStyle: 'medium' });
+
+    const call = (Intl.DateTimeFormat as any).calls.argsFor(0);
+
+    expect(call[1].dateStyle).toEqual('full');
   });
 
   it('should handle none date values', () => {


### PR DESCRIPTION
Hi, this is my first time doing a PR. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features):
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Error in Firefox. No dates are displayed.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
Fixes #324 


## What is the new behavior?
It works now again in Firefox.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
See for Reference
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/79#JavaScript
