### PR TITLE
docs: fix a typo in "Scope Configuration" page

### DIFF
--- a/docs/docs/scope-configuration.mdx
+++ b/docs/docs/scope-configuration.mdx
@@ -23,7 +23,7 @@ There are 3 levels of setting the translation scope:
 
 ## Lazy Module Providers
 
-We can set it inside the _lazy module module_ providers:
+We can set it inside the _lazy module_ providers:
 
 ```ts title="todos.module.ts"
 const routes: Routes = [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

A typo in [Scope Configuration](https://ngneat.github.io/transloco/docs/scope-configuration) page.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

The typo is eliminated.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
