### PR TITLE
docs: fix a typo in "Additional Functionality" page

### DIFF
--- a/docs/docs/additional-functionality.mdx
+++ b/docs/docs/additional-functionality.mdx
@@ -17,7 +17,7 @@ You can point to specific keys in other keys from the same translation file. For
 
 So the result of `service.translate('fromList')` will be: "from home english".
 
-When using this feature inside a [scope](./scope-configuration)), make sure you prefix the key reference with the scope name:
+When using this feature inside a [scope](./scope-configuration), make sure you prefix the key reference with the scope name:
 
 ```json title="admin/en.json"
 {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

A typo in [Additional Functionality](https://ngneat.github.io/transloco/docs/additional-functionality/) page.

## What is the new behavior?

The typo is eliminated.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
