### PR TITLE
plugin: get the currency symbol for the currently set locale

### DIFF
--- a/cypress/integration/locale.ts
+++ b/cypress/integration/locale.ts
@@ -13,6 +13,7 @@ export function testLocaleContentUS() {
   cy.get(`[data-cy=number-percent]`).should('contain', '100%');
 
   // Currency Pipe
+  cy.get(`[data-cy=currency-symbol-only]`).should('contain', '$');
   cy.get(`[data-cy=currency-symbol]`).should('contain', '$1,000,000.00');
   cy.get(`[data-cy=currency-name]`).should('contain', '1,000,000.00 US dollars');
   cy.get(`[data-cy=currency-custom-digit]`).should('contain', '$1,000,000');
@@ -33,6 +34,7 @@ export function testLocaleContentES() {
   cy.get(`[data-cy=number-percent]`).should('contain', '100');
 
   // Currency Pipe
+  cy.get(`[data-cy=currency-symbol-only]`).should('contain', '€');
   cy.get(`[data-cy=currency-symbol]`).should('contain', '1.000.000,00');
   cy.get(`[data-cy=currency-name]`).should('contain', '1.000.000,00 euros');
   cy.get(`[data-cy=currency-custom-digit]`).should('contain', '1.000.000');

--- a/docs/docs/plugins/locale.mdx
+++ b/docs/docs/plugins/locale.mdx
@@ -259,6 +259,7 @@ Note the format option of the global, locale's format and the one's being passed
 - `localizeNumber()` - Transform a number into the locale's number format according to the number type.
 - `getLocale` - Gets the active locale.
 - `setLocale` - Sets the active locale.
+- `getCurrencySymbol` - Gets the currency symbol for a given locale. If no locale is specified the currently active one is used.
 
 ```ts
 translocoLocaleService.localeChanges$.subscribe(activeLocale => ...)
@@ -269,6 +270,8 @@ translocoLocaleService.localizeNumber(1000, 'currency') // $1,000.00
 
 const locale = translocoLocaleService.getLocale();
 translocoLocaleService.setLocale('en-US')
+
+translocoLocaleService.getCurrencySymbol() // $
 ```
 
 ## Localization Transformer

--- a/projects/ngneat/transloco-locale/src/lib/tests/transloco-locale.service.spec.ts
+++ b/projects/ngneat/transloco-locale/src/lib/tests/transloco-locale.service.spec.ts
@@ -7,6 +7,24 @@ import { mockService } from './mocks';
 describe('TranslocoLocaleService', () => {
   let service: TranslocoLocaleService;
 
+  describe('getCurrencySymbol', () => {
+    it('should return symbol for locals with prefix notation', () => {
+      const translocoService: any = {
+        langChanges$: of('en-US')
+      };
+      service = mockService(translocoService);
+      expect(service.getCurrencySymbol()).toEqual('$');
+    });
+
+    it('should return symbol for locals with postfix notation', () => {
+      const translocoService: any = {
+        langChanges$: of('de-DE')
+      };
+      service = mockService(translocoService);
+      expect(service.getCurrencySymbol()).toEqual('€');
+    });
+  });
+
   describe('getLocale', () => {
     it('should return the default locale', () => {
       const translocoService: any = {

--- a/projects/ngneat/transloco-locale/src/lib/transloco-locale.service.ts
+++ b/projects/ngneat/transloco-locale/src/lib/transloco-locale.service.ts
@@ -65,9 +65,9 @@ export class TranslocoLocaleService implements OnDestroy {
   /**
    * Get the currency symbol for the currently set locale.
    */
-  getCurrencySymbol() {
-    const currency = this.localeCurrencyMapping[this._locale];
-    const numberFormat = new Intl.NumberFormat(this._locale, {
+  getCurrencySymbol(locale = this.getLocale()) {
+    const currency = this.localeCurrencyMapping[locale];
+    const numberFormat = new Intl.NumberFormat(locale, {
       style: 'currency',
       currencyDisplay: 'symbol',
       currency: currency,

--- a/projects/ngneat/transloco-locale/src/lib/transloco-locale.service.ts
+++ b/projects/ngneat/transloco-locale/src/lib/transloco-locale.service.ts
@@ -63,6 +63,28 @@ export class TranslocoLocaleService implements OnDestroy {
   }
 
   /**
+   * Get the currency symbol for the currently set locale.
+   */
+  getCurrencySymbol() {
+    const currency = this.localeCurrencyMapping[this._locale];
+    const numberFormat = new Intl.NumberFormat(this._locale, {
+      style: 'currency',
+      currencyDisplay: 'symbol',
+      currency: currency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0
+    });
+
+    const pivot = 0;
+
+    return numberFormat
+      .format(pivot)
+      .split(pivot.toString())
+      .map(element => element.trim())
+      .find(element => !!element);
+  }
+
+  /**
    * Transform a date into the locale's date format.
    *
    * The date expression: a `Date` object, a number

--- a/src/app/locale/locale/locale.component.html
+++ b/src/app/locale/locale/locale.component.html
@@ -46,6 +46,7 @@
 
 <h3 class="mtb">Currency Format</h3>
 <ul class="list-group">
+  <li class="list-group-item" data-cy="currency-symbol-only"><b>Symbol: </b>{{ currencySymbol }}</li>
   <li class="list-group-item" data-cy="currency-symbol"><b>Symbol currency: </b>{{ 1000000 | translocoCurrency }}</li>
   <li class="list-group-item" data-cy="currency-name">
     <b>Name currency: </b>{{ 1000000 | translocoCurrency: 'name' }}

--- a/src/app/locale/locale/locale.component.ts
+++ b/src/app/locale/locale/locale.component.ts
@@ -21,4 +21,8 @@ export class LocaleComponent implements OnInit {
   public setLocale(locale: Locale) {
     this.localeService.setLocale(locale);
   }
+
+  public get currencySymbol() {
+    return this.localeService.getCurrencySymbol();
+  }
 }


### PR DESCRIPTION
There is no clean way to retrieve solely the currency symbol. Therefore a pivot element was chosen to
create a formatted number. In that result the pivot element was removed to retrieve only the currency
symbol.
Depending on the locale the symbol can be on either the left or the right side of the number.

Fixes #339

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

At the moment it is not possibly to retrieve solely the currency symbol of the currently set locale. 

Issue Number: #339 

## What is the new behavior?

The TranslocoLocaleService provides a method that is able to retrieve this symbol. This is done by formatting a 'dummy' number (pivot) and removing the number part. Whats left is basically the currency symbol.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
