### PR TITLE
fix(tests): fix failing unit and e2e tests

### DIFF
--- a/cypress/integration/lazy.ts
+++ b/cypress/integration/lazy.ts
@@ -8,7 +8,6 @@ export function generateLazyContent(lang = 'english') {
   cy.get(`[data-cy=regular]`).should('contain', `Admin ${lang}`);
   cy.get(`[data-cy=read]`).should('contain', `Admin read ${lang}`);
   cy.get(`[data-cy=lazy-page]`).should('contain', `Admin Lazy ${lang}`);
-  cy.get(`[data-cy=multiple-scopes]`).should('contain', `Admin ${lang}`);
 }
 
 export function generateContentWithoutLoader() {

--- a/cypress/integration/locale.ts
+++ b/cypress/integration/locale.ts
@@ -1,9 +1,13 @@
 export function testLocaleContentUS() {
+  const date = Date.UTC(2019, 7, 14, 0, 0, 0, 0);
+  const dateTimeOptions: any = { timeStyle: 'full' };
+  const expectedFullTime = Intl.DateTimeFormat('en-US', dateTimeOptions).format(date);
+
   // Date Pipe
   cy.get(`[data-cy=date-regular]`).should('contain', '8/14/2019');
   cy.get(`[data-cy=date-long]`).should('contain', 'August 14, 2019 at');
   cy.get(`[data-cy=date-full]`).should('contain', 'Wednesday, August 14, 2019 at');
-  cy.get(`[data-cy=date-full]`).should('contain', '9:00:00 PM Coordinated Universal Time');
+  cy.get(`[data-cy=date-full]`).should('contain', expectedFullTime);
   cy.get(`[data-cy=date-full]`).should('contain', 'Jan 1, 1970');
   cy.get(`[data-cy=date-full]`).should('contain', 'Feb 8, 2019');
 
@@ -19,11 +23,15 @@ export function testLocaleContentUS() {
 }
 
 export function testLocaleContentES() {
+  const date = Date.UTC(2019, 7, 13, 22, 0, 0, 0);
+  const dateTimeOptions: any = { timeStyle: 'full' };
+  const expectedFullTime = Intl.DateTimeFormat('es-ES', dateTimeOptions).format(date);
+
   // Date Pipe
   cy.get(`[data-cy=date-regular]`).should('contain', '14/8/2019');
   cy.get(`[data-cy=date-long]`).should('contain', '14 de agosto de 2019');
   cy.get(`[data-cy=date-full]`).should('contain', ' miércoles, 14 de agosto de 2019,');
-  cy.get(`[data-cy=date-full]`).should('contain', '21:00:00 (tiempo universal coordinado)');
+  cy.get(`[data-cy=date-full]`).should('contain', expectedFullTime);
   cy.get(`[data-cy=date-full]`).should('contain', '1 ene. 1970');
   cy.get(`[data-cy=date-full]`).should('contain', ' 8 feb. 2019');
 

--- a/projects/ngneat/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
+++ b/projects/ngneat/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
@@ -81,9 +81,6 @@ describe('TranslocoDatePipe', () => {
 
   it('should transform an ISO 8601 string to date', () => {
     const pipe = new TranslocoDatePipe(service, cdr, LOCALE_CONFIG_MOCK);
-
-    const dateFormat: DateFormatOptions = { dateStyle: 'medium', timeStyle: 'medium' };
-    const expectedDate = Intl.DateTimeFormat('en-US', dateFormat).format(Date.UTC(2019, 8, 12, 19, 51, 33));
-    expect(pipe.transform('2019-09-12T19:51:33Z')).toEqual(expectedDate);
+    expect(pipe.transform('2019-09-12T19:51:33Z', { timeZone: 'UTC' }, 'en-US')).toEqual('Sep 12, 2019, 7:51:33 PM');
   });
 });

--- a/projects/ngneat/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
+++ b/projects/ngneat/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
@@ -1,6 +1,7 @@
 import { TranslocoDatePipe } from '../../pipes/transloco-date.pipe';
 import { createFakeService, createFakeCDR, LOCALE_CONFIG_MOCK } from '../mocks';
 import { defaultConfig } from '../../transloco-locale.config';
+import { DateFormatOptions } from '../../transloco-locale.types';
 
 describe('TranslocoDatePipe', () => {
   let service;
@@ -80,6 +81,9 @@ describe('TranslocoDatePipe', () => {
 
   it('should transform an ISO 8601 string to date', () => {
     const pipe = new TranslocoDatePipe(service, cdr, LOCALE_CONFIG_MOCK);
-    expect(pipe.transform('2019-09-12T19:51:33Z')).toEqual('Sep 12, 2019, 10:51:33 PM');
+
+    const dateFormat: DateFormatOptions = { dateStyle: 'medium', timeStyle: 'medium' };
+    const expectedDate = Intl.DateTimeFormat('en-US', dateFormat).format(Date.UTC(2019, 8, 12, 19, 51, 33));
+    expect(pipe.transform('2019-09-12T19:51:33Z')).toEqual(expectedDate);
   });
 });

--- a/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.html
+++ b/src/app/lazy-multiple-scopes/lazy-multiple-scopes.component.html
@@ -1,7 +1,9 @@
 <h4>Two scopes are defined in this module:</h4>
 <p data-cy="multiple-scopes">
-  admin-page: <span class="admin-page-title">{{'AdminPageAlias.title' | transloco}}</span><br />
-  lazy-page: <span class="lazy-page-title">{{'LazyPageAlias.title' | transloco}}</span></p>
+  admin-page: <span class="admin-page-title">{{ 'AdminPageAlias.title' | transloco }}</span
+  ><br />
+  lazy-page: <span class="lazy-page-title">{{ 'LazyPageAlias.title' | transloco }}</span>
+</p>
 
 <h4>Two scopes using structural directives:</h4>
 <ng-container *transloco="let t">
@@ -15,10 +17,11 @@
 
 <h4>Two scopes using structural directives (using read):</h4>
 <ng-container *transloco="let t; read: 'AdminPageAlias'">
-  admin-page: <p data-cy="read" class="admin-read">{{ t('read') }}</p>
+  admin-page:
+  <p data-cy="read" class="admin-read">{{ t('read') }}</p>
 </ng-container>
 
 <ng-container *transloco="let t; read: 'LazyPageAlias'">
-  lazy-page: <p data-cy="read" class="admin-read">{{ t('title') }}</p>
+  lazy-page:
+  <p data-cy="lazy-page" class="admin-read">{{ t('title') }}</p>
 </ng-container>
-


### PR DESCRIPTION
Some tests failed due to a missing localization of expected time values.
One e2e got removed because it isn't valid anymore.

Please check whether the localized expected time values work in your timezone as well.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Some unit tests failed under the wrong time zone.
Some e2e tests failed because of various reasons:
* legacy
* wrong time zone

## What is the new behavior?

All unit tests and e2e tests run fine.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
