### PR TITLE
feat: 🎸 expose currentLang in structural directive

### DIFF
--- a/cypress/integration/home.ts
+++ b/cypress/integration/home.ts
@@ -3,6 +3,7 @@ export function testHomeContent(lang = 'english') {
   cy.get(`[data-cy=regular]`).should('contain', `home ${lang}`);
   cy.get(`[data-cy=with-params]`).should('contain', `alert 🦄 ${lang}`);
   cy.get(`[data-cy=with-translation-reuse]`).should('contain', `a.b.c from list ${lang}`);
+  cy.get(`[data-cy=current-lang]`).should('contain', `en`);
 
   // Directive
   cy.get(`[data-cy=d-regular] span`).should('contain', `home ${lang}`);

--- a/docs/docs/structural-directive.mdx
+++ b/docs/docs/structural-directive.mdx
@@ -39,11 +39,11 @@ We can instruct the directive to use a `different` language in our template:
 
 This will translate each key based on the `Spanish` language translation file.
 
-## Get the active language
+## Get the current language
 We can obtain the current language key for use in other contexts without injecting the service.
 ```html {1} title="home.component.html"
 <ng-container *transloco="let t; currentLang as currentLang">
-  <p>The active language key is {{ currentLang }}</p>
+  <p>The current language key is {{ currentLang }}</p>
 </ng-container>
 ```
 

--- a/docs/docs/structural-directive.mdx
+++ b/docs/docs/structural-directive.mdx
@@ -39,6 +39,14 @@ We can instruct the directive to use a `different` language in our template:
 
 This will translate each key based on the `Spanish` language translation file.
 
+## Get the active language
+We can obtain the current language key for use in other contexts without injecting the service.
+```html {1} title="home.component.html"
+<ng-container *transloco="let t; currentLang as currentLang">
+  <p>The active language key is {{ currentLang }}</p>
+</ng-container>
+```
+
 ## Utilizing the read input
 We can use the `read` input in the structural directive to get translations of a particular nested (including deeply nested) property.
 

--- a/projects/ngneat/transloco/src/lib/tests/directive/structural.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/directive/structural.spec.ts
@@ -130,4 +130,35 @@ describe('Structural directive', () => {
       testTranslationWithRead(spectator);
     }));
   });
+
+  describe('CurrentLang', () => {
+    let service;
+
+    beforeEach(fakeAsync(() => {
+      spectator = createHost(
+        `
+        <section *transloco="let t; currentLang as currentLang">
+           <div>{{ currentLang }}</div>
+        </section>
+     `,
+        { detectChanges: false }
+      );
+      service = spectator.get(TranslocoService) as any;
+      setlistenToLangChange(service);
+      spectator.detectChanges();
+      runLoader();
+    }));
+
+    it('should expose currentLang to the template', fakeAsync(() => {
+      spectator.detectChanges();
+      expect(spectator.queryHost('div')).toHaveText('en');
+    }));
+
+    it('should change on langChanges', fakeAsync(() => {
+      (service as TranslocoService).setActiveLang('es');
+      runLoader();
+      spectator.detectChanges();
+      expect(spectator.queryHost('div')).toHaveText('es');
+    }));
+  });
 });

--- a/projects/ngneat/transloco/src/lib/transloco.directive.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.directive.ts
@@ -50,7 +50,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
 
   constructor(
     private translocoService: TranslocoService,
-    @Optional() private tpl: TemplateRef<{ $implicit: (key: string, params?: HashMap) => any }>,
+    @Optional() private tpl: TemplateRef<{ $implicit: (key: string, params?: HashMap) => any; currentLang: string }>,
     @Optional() @Inject(TRANSLOCO_SCOPE) private providerScope: MaybeArray<TranslocoScope>,
     @Optional() @Inject(TRANSLOCO_LANG) private providerLang: string | null,
     @Optional() @Inject(TRANSLOCO_LOADING_TEMPLATE) private providedLoadingTpl: Type<any> | string,
@@ -111,10 +111,12 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
     if (this.view) {
       // when the lang changes we need to change the reference so Angular will update the view
       this.view.context['$implicit'] = this.getTranslateFn(lang, read);
+      this.view.context['currentLang'] = this.currentLang;
     } else {
       this.detachLoader();
       this.view = this.vcr.createEmbeddedView(this.tpl, {
-        $implicit: this.getTranslateFn(lang, read)
+        $implicit: this.getTranslateFn(lang, read),
+        currentLang: this.currentLang
       });
     }
   }

--- a/src/app/on-push/on-push.component.html
+++ b/src/app/on-push/on-push.component.html
@@ -1,13 +1,14 @@
 <h3 class="mb">Structural Directive</h3>
-<ng-container *transloco="let t">
+<ng-container *transloco="let t; currentLang as currentLang">
   <ul class="list-group structural">
     <li class="list-group-item" data-cy="regular"><b>Regular: </b>{{ t('home') }}</li>
     <li class="list-group-item" data-cy="with-params"><b>With params: </b>{{ t('alert', { value: dynamic }) }}</li>
     <li class="list-group-item" data-cy="with-translation-reuse"><b>With translation reuse: </b> {{ t('a.b.c') }}</li>
+    <li class="list-group-item" data-cy="current-lang"><b>Current Lang: </b>{{ currentLang }}</li>
   </ul>
 </ng-container>
 
-<h3 class="mtb">Directive</h3>
+<h3 class="mtb" *ngFor="let i of [0]">Directive</h3>
 <ul class="list-group">
   <li class="list-group-item" data-cy="d-regular"><b>Regular: </b><span transloco="home"></span></li>
   <li class="list-group-item" (click)="changeParam()" data-cy="d-with-params">

--- a/src/app/on-push/on-push.component.html
+++ b/src/app/on-push/on-push.component.html
@@ -8,7 +8,7 @@
   </ul>
 </ng-container>
 
-<h3 class="mtb" *ngFor="let i of [0]">Directive</h3>
+<h3 class="mtb">Directive</h3>
 <ul class="list-group">
   <li class="list-group-item" data-cy="d-regular"><b>Regular: </b><span transloco="home"></span></li>
   <li class="list-group-item" (click)="changeParam()" data-cy="d-with-params">

--- a/src/app/on-push/on-push.component.spec.ts
+++ b/src/app/on-push/on-push.component.spec.ts
@@ -18,11 +18,14 @@ describe('OnPushComponent', () => {
 
   it('should translate', () => {
     expect(spectator.query('.structural [data-cy=regular]')).toHaveText('Regular: home spanish');
+    expect(spectator.query('.structural [data-cy=current-lang]')).toHaveText('Current Lang: es');
+    expect(spectator.query('.pipe [data-cy=p-regular]')).toHaveText('Regular: home spanish');
     expect(spectator.query('.pipe [data-cy=p-regular]')).toHaveText('Regular: home spanish');
     const service = spectator.get(TranslocoService);
     service.setActiveLang('en');
     spectator.detectChanges();
     expect(spectator.query('.structural [data-cy=regular]')).toHaveText('Regular: home english');
+    expect(spectator.query('.structural [data-cy=current-lang]')).toHaveText('Current Lang: en');
     expect(spectator.query('.pipe [data-cy=p-regular]')).toHaveText('Regular: home english');
   });
 });


### PR DESCRIPTION
Make currentLang available in the recommended approach, the structural directive, to prevent having to inject the service in instances where obtaining the language is the only required usage.

Closes ngneat/transloco#376

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #376 

## What is the new behavior?

Make currentLang available in the recommended approach, the structural directive, to prevent having to inject the service in instances where obtaining the language is the only required usage.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
N/A