### PR TITLE
docs: rename Transloco testing module filename

### DIFF
--- a/docs/docs/unit-testing.mdx
+++ b/docs/docs/unit-testing.mdx
@@ -6,7 +6,7 @@ description: Unit Testing | Transloco Angular i18n
 When running specs, we want to have the languages available immediately, in a synchronous fashion. Transloco provides you with a `TranslocoTestingModule`, where you can pass the languages you need in your specs, and the config.
 
 We recommend to be DRY and create a module factory function that we can use in each spec, For example:
-```ts title="transloco-module.spec.ts"
+```ts title="transloco-testing.module.ts"
 
 import { TranslocoTestingModule, TranslocoTestingOptions } from '@ngneat/transloco';
 import en from '../assets/i18n/en.json';
@@ -49,7 +49,7 @@ You can find an example [here](https://github.com/ngneat/transloco/blob/master/s
 
 If you need to test `scopes`, you should add them as `languages`, for example:
 
-```ts {6,7} title="transloco-module.spec.ts"
+```ts {6,7} title="transloco-testing.module.ts"
 export function getTranslocoModule(options: TranslocoTestingOptions = {}) {
   return TranslocoTestingModule.forRoot({
     langs: { 


### PR DESCRIPTION
Don't suggest naming the Transloco testing module file name as `.spec` , as this will throw an error for not having any real test inside it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
