### PR TITLE
docs: add additional libraries page

### DIFF
--- a/docs/docs/additional-libraries/components.mdx
+++ b/docs/docs/additional-libraries/components.mdx
@@ -1,0 +1,6 @@
+---
+title: Components
+description: Additional Libraries - Components | Transloco Angular i18n
+---
+
+- [ngx-flag-picker](https://github.com/iamartyom/ngx-flag-picker) - Customizable Angular component which containing a dropdown with country flags.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -79,6 +79,11 @@ module.exports = {
       items: ['plugins/message-format', 'plugins/persist', 'plugins/preload', 'plugins/locale', 'plugins/third-party']
     },
     {
+      type: 'category',
+      label: 'Additional Libraries',
+      items: ['additional-libraries/components']
+    },
+    {
       type: 'doc',
       id: 'schematics'
     },


### PR DESCRIPTION
I created new page in documentation - "Additional libraries".
This page can used for external libraries like components related i18n but not have transloco in dependencies.

I added first my component. This is simple dropdown with country flags. I think it will be useful to someone as a component for choosing the required language.

Demo with this component - https://iamartyom.github.io/ngx-flag-picker/.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
