### PR TITLE
feat: allow to specify options when setting translations by key

### DIFF
--- a/docs/docs/translation-api.mdx
+++ b/docs/docs/translation-api.mdx
@@ -271,6 +271,7 @@ export class AppComponent {
     this.translocoService.setTranslationKey('key', 'value');
     this.translocoService.setTranslationKey('key.nested', 'value');
     this.translocoService.setTranslationKey('key', 'value', 'en');
+    this.translocoService.setTranslationKey('key', 'value', 'en', { emitChange: false });
   }
 }
 ```

--- a/projects/ngneat/transloco/src/lib/tests/service/setTranslationKey.spec.ts
+++ b/projects/ngneat/transloco/src/lib/tests/service/setTranslationKey.spec.ts
@@ -28,4 +28,11 @@ describe('setTranslationKey', () => {
       a: 'new value'
     });
   }));
+
+  it('should not emit the change if option is set', fakeAsync(() => {
+    loadLang(service);
+    spyOn(service, 'setActiveLang');
+    service.setTranslationKey('a.b', 'newValue', 'en', { emitChange: false });
+    expect(service.setActiveLang).not.toHaveBeenCalled();
+  }));
 });

--- a/projects/ngneat/transloco/src/lib/transloco.service.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.service.ts
@@ -414,15 +414,16 @@ export class TranslocoService implements OnDestroy {
    * setTranslationKey('key', 'value')
    * setTranslationKey('key.nested', 'value')
    * setTranslationKey('key.nested', 'value', 'en')
+   * setTranslationKey('key.nested', 'value', 'en', { emitChange: false } )
    */
-  setTranslationKey(key: string, value: string, lang = this.getActiveLang()) {
+  setTranslationKey(key: string, value: string, lang = this.getActiveLang(), options: SetTranslationOptions = {}) {
     const withHook = this.interceptor.preSaveTranslationKey(key, value, lang);
     const newValue = {
       ...this.getTranslation(lang),
       [key]: withHook
     };
 
-    this.setTranslation(newValue, lang);
+    this.setTranslation(newValue, lang, options);
   }
 
   /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When setting the translation using ``setTranslationKey`` from TranslocoService, there is no way to specify translation option. 

Issue Number: N/A

## What is the new behavior?

You can specify translation options in the  ``setTranslationKey`` method. It just passes them to the inner call of ``setTranslation``.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```