### PR TITLE
feat(): add a option to disable automatic language mapping to locale

### DIFF
--- a/projects/ngneat/transloco-locale/README.md
+++ b/projects/ngneat/transloco-locale/README.md
@@ -184,6 +184,7 @@ Let's go over each one of the `config` options:
 - `defaultCurrency?`: The default currency formatted in [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) (default value: `USD`),
 - `langToLocaleMapping?`: A key value `object` that maps Transloco language to it's Locale (default value: `{}`).
 - `localeToCurrencyMapping?`: A key value `object` that maps the Locale to it's currency (formatted in [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html)) (the library provide a default value with all of the existing mapping).
+- `langToLocaleMappingEnabled?`: A boolean value to enable or disable setting Transloco active language as locale (default value `true`).
 
 ### Locale Format Options
 

--- a/projects/ngneat/transloco-locale/src/lib/tests/mocks.ts
+++ b/projects/ngneat/transloco-locale/src/lib/tests/mocks.ts
@@ -8,7 +8,7 @@ import createSpy = jasmine.createSpy;
 import { LocaleConfig } from '../../lib/transloco-locale.config';
 
 export function createFakeService(locale: Locale = 'en-US') {
-  return mockService(mockTranslocoService(locale), locale);
+  return mockService({ translocoService: mockTranslocoService(locale), locale });
 }
 
 export function createFakeCDR(locale: string = 'en-US') {
@@ -21,6 +21,7 @@ export const LOCALE_CURRENCY_MOCK = LOCALE_CURRENCY;
 export const LANG_LOCALE_MOCK = { en: 'en-US', es: 'es-ES' };
 export const DEFAULT_LOCALE_MOCK = 'en-US';
 export const DEFAULT_CURRENCY_MOCK = 'USD';
+export const LOCALE_ENABLE_LANG_MAPPING_MOCK = true;
 export const LOCALE_CONFIG_MOCK: LocaleConfig = {
   global: {
     decimal: {
@@ -66,23 +67,31 @@ export const mockTranslocoService = (locale?: Locale): TranslocoService =>
   ({
     langChanges$: locale ? of(locale) : of()
   } as any);
-export const mockService = (
-  translocoService = mockTranslocoService(),
-  locale = DEFAULT_LOCALE_MOCK,
-  currency = DEFAULT_CURRENCY_MOCK,
-  langLocale = LANG_LOCALE_MOCK,
-  config = LOCALE_CONFIG_MOCK,
-  localeCurrencyMapping = LOCALE_CURRENCY_MOCK,
-  numberTransformer = new DefaultNumberTransformer(),
-  dateTransformer = new DefaultDateTransformer()
-) =>
-  new TranslocoLocaleService(
-    translocoService,
-    langLocale,
-    locale,
-    currency,
-    config,
-    localeCurrencyMapping,
-    numberTransformer,
-    dateTransformer
+
+const defaultMockConf = {
+  translocoService: mockTranslocoService(),
+  locale: DEFAULT_LOCALE_MOCK,
+  currency: DEFAULT_CURRENCY_MOCK,
+  langLocale: LANG_LOCALE_MOCK,
+  config: LOCALE_CONFIG_MOCK,
+  localeCurrencyMapping: LOCALE_CURRENCY_MOCK,
+  numberTransformer: new DefaultNumberTransformer(),
+  dateTransformer: new DefaultDateTransformer(),
+  langToLocaleMappingEnabled: LOCALE_ENABLE_LANG_MAPPING_MOCK
+};
+
+export const mockService = (mockConf?: Partial<typeof defaultMockConf>): TranslocoLocaleService => {
+  const conf = Object.assign({}, defaultMockConf, mockConf);
+
+  return new TranslocoLocaleService(
+    conf.translocoService,
+    conf.langLocale,
+    conf.locale,
+    conf.currency,
+    conf.config,
+    conf.localeCurrencyMapping,
+    conf.numberTransformer,
+    conf.dateTransformer,
+    conf.langToLocaleMappingEnabled
   );
+};

--- a/projects/ngneat/transloco-locale/src/lib/transloco-locale.config.ts
+++ b/projects/ngneat/transloco-locale/src/lib/transloco-locale.config.ts
@@ -21,6 +21,7 @@ export interface TranslocoLocaleConfig {
   localeConfig?: LocaleConfig;
   langToLocaleMapping?: HashMap<Locale>;
   localeToCurrencyMapping?: HashMap<Currency>;
+  langToLocaleMappingEnabled?: boolean;
 }
 
 export const defaultConfig: TranslocoLocaleConfig = {
@@ -31,7 +32,8 @@ export const defaultConfig: TranslocoLocaleConfig = {
   defaultLocale: 'en-US',
   defaultCurrency: 'USD',
   localeToCurrencyMapping: LOCALE_CURRENCY,
-  langToLocaleMapping: {}
+  langToLocaleMapping: {},
+  langToLocaleMappingEnabled: true
 };
 
 export const LOCALE_DEFAULT_LOCALE = new InjectionToken<NumberFormatOptions>('DEFAULT_LOCALE');
@@ -39,3 +41,4 @@ export const LOCALE_DEFAULT_CURRENCY = new InjectionToken<NumberFormatOptions>('
 export const LOCALE_LANG_MAPPING = new InjectionToken<HashMap<Locale>>('LOCALE_LANG_MAPPING');
 export const LOCALE_CONFIG = new InjectionToken<HashMap<LocaleFormatOptions>>('LOCALE_CONFIG');
 export const LOCALE_CURRENCY_MAPPING = new InjectionToken<HashMap<Currency>>('LOCALE_CURRENCY_MAPPING');
+export const LOCALE_ENABLE_LANG_MAPPING = new InjectionToken<boolean>('LOCALE_ENABLE_LANG_MAPPING');

--- a/projects/ngneat/transloco-locale/src/lib/transloco-locale.module.ts
+++ b/projects/ngneat/transloco-locale/src/lib/transloco-locale.module.ts
@@ -10,7 +10,8 @@ import {
   defaultConfig,
   LOCALE_DEFAULT_LOCALE,
   LOCALE_CONFIG,
-  LOCALE_DEFAULT_CURRENCY
+  LOCALE_DEFAULT_CURRENCY,
+  LOCALE_ENABLE_LANG_MAPPING
 } from './transloco-locale.config';
 import {
   TRANSLOCO_DATE_TRANSFORMER,
@@ -57,6 +58,10 @@ export class TranslocoLocaleModule {
         {
           provide: TRANSLOCO_NUMBER_TRANSFORMER,
           useClass: DefaultNumberTransformer
+        },
+        {
+          provide: LOCALE_ENABLE_LANG_MAPPING,
+          useValue: config.langToLocaleMappingEnabled || defaultConfig.langToLocaleMappingEnabled
         }
       ]
     };


### PR DESCRIPTION
Updates Unit tests for transloco locale

Closes #462

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #462

## What is the new behavior?
A new optional configuration property that disables the automatic linking of language and locale allowing both to be used as standalone libraries.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
