### PR TITLE
fix: allow `TranslocoService` to be garbage collected

### DIFF
--- a/projects/ngneat/transloco/src/lib/transloco.service.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.service.ts
@@ -515,6 +515,11 @@ export class TranslocoService implements OnDestroy {
 
   ngOnDestroy() {
     this.subscription.unsubscribe();
+    // Caretaker note: since this is the root provider, it'll be destroyed when the `NgModuleRef.destroy()` is run.
+    // Cached values capture `this`, thus leading to a circular reference and preventing the `TranslocoService` from
+    // being GC'd. This would lead to a memory leak when server-side rendering is used since the service is created
+    // and destroyed per each HTTP request, but any service is not getting GC'd.
+    this.cache.clear();
   }
 
   private isLoadedTranslation(lang: string) {


### PR DESCRIPTION
Hey! I've noticed that `TranslocoService` is not getting GC'd when the app is destroyed, since cached values are capturing `this` (see code comments):

![cache-leak](https://user-images.githubusercontent.com/7337691/124449393-199fe000-dd8c-11eb-9896-8049d187d6cc.png)
