### PR TITLE
style(docs): make code samples into note sections more readable

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -91,6 +91,10 @@ header.hero .hero__subtitle {
   color: #e6e6e6;
 }
 
+[data-theme=dark] .admonition-content code {
+  color: inherit;
+}
+
 [data-theme='dark'] .main-wrapper {
   background-color: #282c35;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

It changes the color of code samples included in the note sections of the documentation on dark mode.

Affected documentation pages : 
- [Installation](https://ngneat.github.io/transloco/docs/installation)
- [Language API](https://ngneat.github.io/transloco/docs/language-api)
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: style change
```

## What is the current behavior?

The code samples included into `::note` sections are hard to read on dark mode :
![image](https://user-images.githubusercontent.com/32737308/125161515-1c7f4400-e183-11eb-9935-80f0f1019aa9.png)


Issue Number: #475

## What is the new behavior?

The color of the code samples changed : 

![image](https://user-images.githubusercontent.com/32737308/125161552-3f115d00-e183-11eb-9884-7fbab7c7b2ef.png)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
