### PR TITLE
docs: fix include default language flag

### DIFF
--- a/docs/docs/schematics.mdx
+++ b/docs/docs/schematics.mdx
@@ -272,7 +272,7 @@ The default language of the project
 
 Determine rather to join also the default language
 
-- `--include-defaultLang`
+- `--include-default-lang`
 
   `type`: `boolean`
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The documented flag `--include-defaultLang` is not working, because it should be either dash-case or camelCase.
https://ngneat.github.io/transloco/docs/schematics/#options-3

## What is the new behavior?

The correct flag is documented. Changed the parameter inside the docs to `--include-defaultLang`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
