### PR TITLE
feat: add possibility of override `getTranslateFn`

### DIFF
--- a/projects/ngneat/transloco/src/lib/transloco.directive.ts
+++ b/projects/ngneat/transloco/src/lib/transloco.directive.ts
@@ -121,7 +121,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  private getTranslateFn(lang: string, read: string | undefined): (key: string, params?: HashMap) => any {
+  protected getTranslateFn(lang: string, read: string | undefined): (key: string, params?: HashMap) => any {
     return (key: string, params: HashMap) => {
       const withRead = read ? `${read}.${key}` : key;
       const withParams = params ? `${withRead}${JSON.stringify(params)}` : withRead;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently we can't override the `getTranslateFn` as it's `private`.

Issue Number:
Closes #489.

## What is the new behavior?
This changes `getTranslateFn` to be `protected` and so we can override it in order to make it work with the cases mentioned on #489.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information