### PR TITLE
fix(messageformattranspiler): correctly set locale parser

### DIFF
--- a/docs/docs/plugins/message-format.mdx
+++ b/docs/docs/plugins/message-format.mdx
@@ -50,7 +50,10 @@ By default, messageformat initializes _all_ locales. You could also provide the 
   imports: [
     TranslocoMessageFormatModule.init(
       {
-        locales: 'en-GB'
+        locales: 'en-GB',
+        langToLocaleMapping: {
+          en: 'en-GB',
+        }
       }
     )
   ],
@@ -60,6 +63,8 @@ export class TranslocoRootModule {}
 ```
 
 The value for `locales` is either a string or an array of strings. The first locale is used as the default locale by messageformat. More info [here](https://messageformat.github.io/messageformat/MessageFormat).
+
+The `langToLocaleMapping` is optional and by default tries to get the value from TranslocoLocale config and can be overridden here. The keys should correspond to the languages used by and provided to Transloco Config 
 
 ## Advanced configuration
 MessageFormat instances provide some methods to influence its behaviour, among them `addFormatters`, `setBiDiSupport`, and `setStrictNumberSign`. Learn about their meaning [here](https://messageformat.github.io/messageformat/MessageFormat)

--- a/projects/ngneat/transloco-messageformat/src/lib/messageformat.config.ts
+++ b/projects/ngneat/transloco-messageformat/src/lib/messageformat.config.ts
@@ -1,6 +1,8 @@
 import { InjectionToken } from '@angular/core';
 
 import * as MessageFormat from 'messageformat';
+import { HashMap } from '@ngneat/transloco';
+import { Locale } from '@ngneat/transloco-locale';
 
 export const TRANSLOCO_MESSAGE_FORMAT_CONFIG = new InjectionToken<MessageformatConfig>(
   'TRANSLOCO_MESSAGE_FORMAT_CONFIG'
@@ -10,4 +12,5 @@ export type MFLocale = { [locale: string]: Function } | string[] | string;
 
 export interface MessageformatConfig extends MessageFormat.Options {
   locales?: MFLocale;
+  langToLocaleMapping?: HashMap<Locale>;
 }

--- a/projects/ngneat/transloco-messageformat/src/lib/messageformat.transpiler.spec.ts
+++ b/projects/ngneat/transloco-messageformat/src/lib/messageformat.transpiler.spec.ts
@@ -167,4 +167,59 @@ describe('MessageFormatTranspiler', () => {
     parser.setLocale('pl');
     expect(parser.transpile(polishKey, params, {})).toBe('2 things');
   });
+
+  describe('Without lang to locale mapping', () => {
+    it(`Should throw error that locale is not found`, () => {
+      const locales = ['en-US'];
+      const parserWithLangToLocaleMapping = new MessageFormatTranspiler({ locales }, translocoConfig());
+      expect(function() {
+        parserWithLangToLocaleMapping.onLangChanged('other');
+      }).toThrowError('Localisation function not found for locale "other"');
+    });
+  });
+
+  describe('Lang to locale mapping from config', () => {
+    it(`Should use lang to locale mapping without any error`, () => {
+      const key = 'The { gender, select, male {boy won his} female {girl won her} other {person won their}} race';
+      const locales = ['en-US'];
+      const langToLocaleMapping = {
+        en: 'en-US',
+        other: 'en-US'
+      };
+      const parserWithLangToLocaleMapping = new MessageFormatTranspiler(
+        { locales, langToLocaleMapping },
+        translocoConfig()
+      );
+      const enResult = parserWithLangToLocaleMapping.transpile(key, { gender: 'male' }, {});
+      expect(function() {
+        parserWithLangToLocaleMapping.onLangChanged('other');
+      }).not.toThrowError('Localisation function not found for locale "other"');
+      const otherResult = parserWithLangToLocaleMapping.transpile(key, { gender: 'male' }, {});
+      expect(enResult).toEqual(otherResult);
+    });
+  });
+
+  describe('Lang to locale mapping from TranslocoLocale', () => {
+    it(`Should use lang to locale mapping without any error`, () => {
+      const key = 'The { gender, select, male {boy won his} female {girl won her} other {person won their}} race';
+
+      const locales = ['en-US'];
+      const langToLocaleMapping = {
+        en: 'en-US',
+        other: 'en-US'
+      };
+      const parserWithLangToLocaleMapping = new MessageFormatTranspiler(
+        { locales },
+        translocoConfig(),
+        langToLocaleMapping
+      );
+
+      const enResult = parserWithLangToLocaleMapping.transpile(key, { gender: 'male' }, {});
+      expect(function() {
+        parserWithLangToLocaleMapping.onLangChanged('other');
+      }).not.toThrowError('Localisation function not found for locale "other"');
+      const otherResult = parserWithLangToLocaleMapping.transpile(key, { gender: 'male' }, {});
+      expect(enResult).toEqual(otherResult);
+    });
+  });
 });

--- a/projects/ngneat/transloco-messageformat/src/lib/messageformat.transpiler.ts
+++ b/projects/ngneat/transloco-messageformat/src/lib/messageformat.transpiler.ts
@@ -11,6 +11,7 @@ import {
 } from '@ngneat/transloco';
 
 import * as MessageFormat from 'messageformat';
+import { LOCALE_LANG_MAPPING, Locale } from '@ngneat/transloco-locale';
 import { MessageformatConfig, MFLocale, TRANSLOCO_MESSAGE_FORMAT_CONFIG } from './messageformat.config';
 
 function mfFactory(locales?: MFLocale, messageConfig?: MessageFormat.Options): MessageFormat {
@@ -22,14 +23,17 @@ function mfFactory(locales?: MFLocale, messageConfig?: MessageFormat.Options): M
 export class MessageFormatTranspiler extends DefaultTranspiler {
   private messageFormat: MessageFormat;
   private messageConfig: MessageFormat.Options;
+  private langToLocaleMapping: HashMap<Locale>
 
   constructor(
     @Optional() @Inject(TRANSLOCO_MESSAGE_FORMAT_CONFIG) config: MessageformatConfig,
-    @Optional() @Inject(TRANSLOCO_CONFIG) userConfig?: TranslocoConfig
+    @Optional() @Inject(TRANSLOCO_CONFIG) userConfig?: TranslocoConfig,
+    @Optional() @Inject(LOCALE_LANG_MAPPING) langToLocaleMapping?: HashMap<Locale>
   ) {
     super(userConfig);
     const { locales, ...messageConfig } = config || { locales: undefined };
     this.messageConfig = messageConfig;
+    this.langToLocaleMapping = langToLocaleMapping || messageConfig.langToLocaleMapping;
     this.messageFormat = mfFactory(locales, messageConfig);
   }
 
@@ -58,7 +62,7 @@ export class MessageFormatTranspiler extends DefaultTranspiler {
   }
 
   onLangChanged(lang: string) {
-    this.setLocale(lang);
+    this.setLocale(this.langToLocaleMapping ? this.langToLocaleMapping[lang] : lang);
   }
 
   setLocale(locale: MFLocale) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

This PR uses langToLocaleMapping from tarnsloco locale or messageformat options to parse lang to locale used by message format.

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currentyl MessageFormatTranspiler just sets lang as locale which may break messageformat library with error that such locale cannot be found.

Issue Number: 501

## What is the new behavior?

Lang is translated using mapping from transloco locale or mf config

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

