### PR TITLE
fix: transloco fallback strategy class is not decorated

### DIFF
--- a/libs/transloco/src/lib/transloco-fallback-strategy.ts
+++ b/libs/transloco/src/lib/transloco-fallback-strategy.ts
@@ -1,4 +1,4 @@
-import { Inject, InjectionToken } from '@angular/core';
+import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { TRANSLOCO_CONFIG, TranslocoConfig } from './transloco.config';
 
 export const TRANSLOCO_FALLBACK_STRATEGY =
@@ -8,6 +8,7 @@ export interface TranslocoFallbackStrategy {
   getNextLangs(failedLang: string): string[];
 }
 
+@Injectable()
 export class DefaultFallbackStrategy implements TranslocoFallbackStrategy {
   constructor(@Inject(TRANSLOCO_CONFIG) private userConfig: TranslocoConfig) {}
 


### PR DESCRIPTION
TranslocoFallbackStrategy is using angular Inject decorator but itself is not decorated, causing the generated bundle to be invalid when using ivy renderer

## PR Checklist

- [X] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

DefaultFallbackStrategy class is not a valid Angular provider and can't injected. Since it's using `@Inject` decorator in constructor, itself must be decorated with `@Injectable`

Issue Number: N/A

## What is the new behavior?

DefaultFallbackStrategy is now a valid provider

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

## Other information

https://stackblitz.com/edit/ngneat-transloco-jdldhs
