### PR TITLE
Feature/langChanged event

### DIFF
--- a/docs/docs/translation-api.mdx
+++ b/docs/docs/translation-api.mdx
@@ -293,6 +293,11 @@ export class AppComponent {
       filter(e => e.type === 'translationLoadFailure'),
       pluck('payload')
     ).subscribe(({ langName, scope }) => ...);
+    
+    this.translocoService.events$.pipe(
+      filter(e => e.type === 'langChanged'),
+      pluck('payload')
+    ).subscribe(({ langName, scope }) => ...);
 }
 ```
 

--- a/libs/transloco/src/lib/tests/service/load.spec.ts
+++ b/libs/transloco/src/lib/tests/service/load.spec.ts
@@ -39,6 +39,18 @@ describe('load', () => {
     });
   }));
 
+  it('should trigger lang changed once loaded', fakeAsync(() => {
+    const spy = jasmine.createSpy();
+    service.events$
+      .pipe(
+        filter((e: any) => e.type === 'langChanged'),
+      )
+      .subscribe(event => {
+        expect(event.type).toEqual('langChanged');
+      });
+    loadLang(service, 'admin-page/en');
+  }));
+
   it('should load the translation using the loader', fakeAsync(() => {
     const loaderSpy = spyOn(
       (service as any).loader,

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -161,7 +161,10 @@ export class TranslocoService implements OnDestroy {
   setActiveLang(lang: string) {
     this.lang.next(lang);
     this.parser.onLangChanged?.(lang);
-
+    this.events.next({
+      type: 'langChanged',
+      payload: getEventPayload(lang),
+    });
     return this;
   }
 

--- a/libs/transloco/src/lib/types.ts
+++ b/libs/transloco/src/lib/types.ts
@@ -14,7 +14,12 @@ export interface FailedEvent {
   payload: LoadedEvent['payload'];
 }
 
-export type TranslocoEvents = LoadedEvent | FailedEvent;
+export interface LangChangedEvent {
+  type: 'langChanged';
+  payload: LoadedEvent['payload'];
+}
+
+export type TranslocoEvents = LoadedEvent | FailedEvent | LangChangedEvent;
 export type Translation = HashMap;
 export type PersistStorage = Pick<
   Storage,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

It adds "langChanged" event.type to be emitted by "events$" observable

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

currently "events$" only emits "translationLoadFailure" and "translationLoadSuccess" event types.

Issue Number: #461 

## What is the new behavior?

"events$" now emits "langChanged" as an event.type when setting an active language AFTER triggering "onLangChanged"

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

## Other information
