### PR TITLE
fix(scoped-libs): remove typo in the main property

### DIFF
--- a/libs/transloco-scoped-libs/package.json
+++ b/libs/transloco-scoped-libs/package.json
@@ -2,7 +2,7 @@
   "name": "@ngneat/transloco-scoped-libs",
   "version": "3.0.3",
   "description": "Transloco support tool for libraries with translations",
-  "main": "src/lib/transloco-scroped-libs.js",
+  "main": "src/lib/transloco-scoped-libs.js",
   "bin": {
     "transloco-scoped-libs": "src/index.js"
   },


### PR DESCRIPTION
The typo in the main property is causing issues while importing the library, as the referenced files
does not exist.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `main` property in the `package.json` has a typo, which results in problems for TypeScript, as it can't find the given main file.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The library can be used with as `import` in TypeScript without an issue.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
