### PR TITLE
fix(transloco): 🐛 Add generic type default to Translate<T>()

### DIFF
--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -80,12 +80,12 @@ import { resolveLoader } from './resolve-loader';
 
 let service: TranslocoService;
 
-export function translate<T>(
+export function translate<T = string>(
   key: TranslateParams,
   params: HashMap = {},
   lang?: string
 ): T {
-  return service.translate(key, params, lang);
+  return service.translate<T>(key, params, lang);
 }
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Translate function is generically typed as unknown by default.
This causes type errors including:
> Argument of type 'unknown' is not assignable to parameter of type 'string'

Issue Number: #544

## What is the new behavior?
Translate function is generically typed as string by default.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
