### PR TITLE
fix(service): key as array in translateObject throws

### DIFF
--- a/libs/transloco/src/lib/tests/service/translateObject.spec.ts
+++ b/libs/transloco/src/lib/tests/service/translateObject.spec.ts
@@ -34,6 +34,19 @@ describe('translateObject', () => {
     }));
   });
 
+  describe('The key is an array', () => {
+    it('should return two objects', fakeAsync(() => {
+      loadLang(service);
+      expect(service.translateObject(['a', 'nested'])).toEqual([{
+        b: { c: 'a.b.c {{fromList}} english' },
+      },{
+        "title": "Title english",
+        "desc": "Desc english"
+      },
+    ]);
+    }));
+  });
+
   describe('The key is an object', () => {
     it('should return an array', fakeAsync(() => {
       loadLang(service);

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -383,6 +383,7 @@ export class TranslocoService implements OnDestroy {
     lang = this.getActiveLang()
   ): T | T[] {
     if (isString(key) || Array.isArray(key)) {
+      const { resolveLang, scope } = this.resolveLangAndScope(lang);
       if (Array.isArray(key)) {
         return key.map((k) =>
           this.translateObject(
@@ -392,7 +393,6 @@ export class TranslocoService implements OnDestroy {
           )
         ) as any;
       }
-      const { resolveLang, scope } = this.resolveLangAndScope(lang);
 
       const translation = this.getTranslation(resolveLang);
       key = scope ? `${scope}.${key}` : key;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The following code throws "Cannot access 'scope' before initialization
`const result = translateService.translateObject(['object1', 'object2']);``

Issue Number: #576 

## What is the new behavior?
The code does not throw anymore

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
When reverting my changes in the TranslocoService, the test failes with the error written above (to reproduce)
