### PR TITLE
fix: wrong order of language update calls

### DIFF
--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -167,8 +167,8 @@ export class TranslocoService implements OnDestroy {
   }
 
   setActiveLang(lang: string) {
-    this.lang.next(lang);
     this.parser.onLangChanged?.(lang);
+    this.lang.next(lang);
     this.events.next({
       type: 'langChanged',
       payload: getEventPayload(lang),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The language for the parser/transpiler is set after the language of the service is updated.
The update of the language in the service triggers a rerendering - where the parser/transpiler will use the old language.
The problem is only visible if the transpiler is language-sensitive (like the MessageFormatTranspiler) since in the default case the transpiler is getting the language strings from the loader/service which already have the new language set.

Issue Number: N/A

## What is the new behavior?

The language of the transpiler is now changed before the service language is changed. This gives the language-sensitive transpilers the chance to update their data before new renderings occur. 

```
[?] Yes
[?] No
```

Not sure if this is a breaking change. It's also hard to write a test case for this usecase since it's a kind of a race-condition.

## Other information
