### PR TITLE
fix(schematics): set current directory as default project name

### DIFF
--- a/docs/docs/schematics/ng-add.mdx
+++ b/docs/docs/schematics/ng-add.mdx
@@ -61,6 +61,8 @@ Creates boilerplate translation files for the given languages, and adds Transloc
 
   `type`: `string`
 
+  `default`: `project root directory name`
+
 #### Provide the path to a root `Module` and import `TranslocoModule` along with the module's required configuration defined by previous flags.
 
 - `--module`

--- a/libs/transloco-schematics/src/join/schema.json
+++ b/libs/transloco-schematics/src/join/schema.json
@@ -33,7 +33,10 @@
     },
     "project": {
       "type": "string",
-      "description": "The root project name."
+      "description": "The root project name.",
+      "$default": {
+        "$source": "projectName"
+      }
     }
   },
   "required": []

--- a/libs/transloco-schematics/src/keys-manager/schema.json
+++ b/libs/transloco-schematics/src/keys-manager/schema.json
@@ -23,7 +23,10 @@
     },
     "project": {
       "type": "string",
-      "description": "The root project name."
+      "description": "The root project name.",
+      "$default": {
+        "$source": "projectName"
+      }
     }
   },
   "required": []

--- a/libs/transloco-schematics/src/ng-add/schema.json
+++ b/libs/transloco-schematics/src/ng-add/schema.json
@@ -38,7 +38,10 @@
     },
     "project": {
       "description": "The project name.",
-      "type": "string"
+      "type": "string",
+      "$default": {
+        "$source": "projectName"
+      }
     },
     "module": {
       "description": "The root module name.",

--- a/libs/transloco-schematics/src/split/schema.json
+++ b/libs/transloco-schematics/src/split/schema.json
@@ -25,7 +25,10 @@
     },
     "project": {
       "type": "string",
-      "description": "The root project name."
+      "description": "The root project name.",
+      "$default": {
+        "$source": "projectName"
+      }
     }
   },
   "required": []

--- a/libs/transloco-schematics/src/tests/ng-add.spec.ts
+++ b/libs/transloco-schematics/src/tests/ng-add.spec.ts
@@ -1,0 +1,27 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { createWorkspace } from '../utils/create-workspace';
+import { SchemaOptions } from '../ng-add/schema';
+
+const collectionPath = path.join(__dirname, '../collection.json');
+
+describe('ng add', () => {
+  const schematicRunner = new SchematicTestRunner('schematics', collectionPath);
+
+  let appTree: UnitTestTree;
+  beforeEach(async () => {
+    appTree = await createWorkspace(schematicRunner, appTree);
+  });
+  it('should add transloco to specified project', async () => {
+    const options: SchemaOptions = { project: 'bar' } as SchemaOptions;
+    const tree = await schematicRunner
+      .runSchematicAsync('ng-add', options, appTree)
+      .toPromise();
+    expect(tree).toBeDefined();
+    expect(tree.files).toContain('/transloco.config.js');
+    expect(tree.files).toContain('/projects/bar/src/app/transloco-root.module.ts');
+  });
+});


### PR DESCRIPTION
- defaultProject was removed from the cli in angular 14
- this sets current working directory as default if --project argument is not specified

as recommended here : https://github.com/angular/angular-cli/issues/23470#issuecomment-1172240384

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When using the `ng add @ngneat/transloco` schematics with a newly created angular 14 project, it fails with the following error :
 
`Cannot read properties of undefined (reading 'projectType')`

Issue Number: #580

## What is the new behavior?

The command without `--project` argument won't fail, and project arg is pre-filled with root directory name.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```


## Other information

n/a