### PR TITLE
docs(structural-directive): add missing line

### DIFF
--- a/docs/docs/structural-directive.mdx
+++ b/docs/docs/structural-directive.mdx
@@ -68,6 +68,7 @@ we can write:
 ```html {1} title="home.component.html"
 <ng-container *transloco="let t; read: 'dashboard'">
   <p>{{ t('title') }}</p>
+  <p>{{ t('desc') }}</p>
 </ng-container>
 ```
 


### PR DESCRIPTION
Line 71 one is missing the translation of `desc` or line 79 should be removed.

Currently it looks inconsistent to me.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
