### PR TITLE
Add skipGitIgnoreUpdate to watch mode options

### DIFF
--- a/libs/transloco-scoped-libs/src/lib/transloco-scoped-libs.ts
+++ b/libs/transloco-scoped-libs/src/lib/transloco-scoped-libs.ts
@@ -121,6 +121,7 @@ export default function run({
                   outputDir: output,
                   strategy,
                   files: [file],
+                  skipGitIgnoreUpdate,
                   scope,
                 });
               }


### PR DESCRIPTION
This change makes the program behave similarly with and without the --watch flag with respect to --skip-gitignore. Fixes issue #604.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #604

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
