### PR TITLE
fix(service): add overload type in selectTranslateObject method

### DIFF
--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -423,6 +423,11 @@ export class TranslocoService implements OnDestroy {
     lang?: string
   ): Observable<T[]>;
   selectTranslateObject<T = any>(
+    key: TranslateParams,
+    params?: HashMap,
+    lang?: string
+  ): Observable<T> | Observable<T[]>;
+  selectTranslateObject<T = any>(
     key: HashMap | Map<string, HashMap>,
     params?: null,
     lang?: string


### PR DESCRIPTION
Transloco - service:

To match the overloads of transteObject and selectTranslateObject.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
