### PR TITLE
fix(migrate): continue with null value instead of  TypeError: Cannot read property 'trim' of undefined.

### DIFF
--- a/schematics/src/ng-migrate/ng-migrate.ts
+++ b/schematics/src/ng-migrate/ng-migrate.ts
@@ -77,7 +77,12 @@ function getTranslation(template) {
     }
 
     key = kebabCase(key);
-    keyValue = keyValue.trim().replace(/(\r\n|\n|\r)/gm, '');
+    if (keyValue === undefined) {
+      console.warn(`Could not extract value for '${result[0]}'. Note that void elements are not supported.`);
+      keyValue = null; // include in output to make problem easier to notice
+    } else {
+      keyValue = keyValue.trim().replace(/(\r\n|\n|\r)/gm, '');
+    }
 
     if (context) {
       translation[context] = translation[context] || {};


### PR DESCRIPTION
This can happen in the presence of void elements.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
```


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

