### PR TITLE
fix(transloco-locale): fixed letter case sensitivity for scripts

### DIFF
--- a/libs/transloco-locale/src/lib/helpers.ts
+++ b/libs/transloco-locale/src/lib/helpers.ts
@@ -12,11 +12,12 @@ export const ISO8601_DATE_REGEX =
  * isLocaleFormat('en-US') // true
  */
 export function isLocaleFormat(val: any): val is Locale {
-  const irregulars = `en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE|art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang|zh-Hans|zh-hant`;
+  const irregulars = `en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE|art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang`;
   const BCPFormat = `[a-z]{2}-[A-Z]{2}`;
+  const scriptFormat = `[a-z]{2}-[A-Za-z]{4}`;
   return (
     typeof val === 'string' &&
-    !!val.match(RegExp(`(${irregulars})|(${BCPFormat})`))
+    !!val.match(RegExp(`(${irregulars})|(${BCPFormat})|(${scriptFormat})`))
   );
 }
 

--- a/libs/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
+++ b/libs/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
@@ -84,7 +84,7 @@ describe('TranslocoDatePipe', () => {
       cdr,
       defaultConfig.localeConfig
     );
-    expect(pipe.transform(0)).toEqual('1/1/1970');
+    expect(pipe.transform(0, {timeZone: 'UTC'})).toEqual('1/1/1970');
   });
 
   it('should transform string to date', () => {

--- a/libs/transloco-locale/src/lib/tests/transloco-locale.service.spec.ts
+++ b/libs/transloco-locale/src/lib/tests/transloco-locale.service.spec.ts
@@ -80,6 +80,13 @@ describe('TranslocoLocaleService', () => {
       service.setLocale('en-us');
       expect(console.error).toHaveBeenCalledTimes(4);
     });
+
+    it('should allow locale syntax with a case-insensitive script subtag', () => {
+      service.setLocale('zh-Hant');
+      expect(service.getLocale()).toEqual('zh-Hant');
+      service.setLocale('zh-hant');
+      expect(service.getLocale()).toEqual('zh-hant');
+    })
   });
 
   describe('localeChanges$', () => {


### PR DESCRIPTION
Previously, the `TranslocoLocaleService` would only allow "zh-Hans" and "zh-hant" but not "zh-Hant". According to the IETF, script variants _should_ use title case but are not required to do so. This PR adds a RegExp that allows for case-insensitive script variants.

https://en.wikipedia.org/wiki/IETF_language_tag#Syntax_of_language_tags

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #636 

## What is the new behavior?

Any locale specifying a 4-letter script is accepted regardless of the letter case used.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This method `isLocaleFormat` could be enhanced further with support for all types of variants using a large regex such as the one found in [this StackOverflow](https://stackoverflow.com/questions/7035825/regular-expression-for-a-language-tag-as-defined-by-bcp47/7036171#7036171) comment. If the maintainers wish to go that route I'm happy to update this PR accordingly.
