### PR TITLE
perf(transloco): use EmbeddedViewRef to detect changes

### DIFF
--- a/libs/transloco/src/lib/transloco.directive.ts
+++ b/libs/transloco/src/lib/transloco.directive.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectorRef,
   Directive,
   ElementRef,
   EmbeddedViewRef,
@@ -13,23 +12,23 @@ import {
   SimpleChanges,
   TemplateRef,
   Type,
-  ViewContainerRef,
+  ViewContainerRef
 } from '@angular/core';
 import { forkJoin, Observable, Subscription } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
+import { LangResolver } from './lang-resolver';
+import { ScopeResolver } from './scope-resolver';
+import {
+  listenOrNotOperator,
+  resolveInlineLoader,
+  shouldListenToLangChanges
+} from './shared';
 import { TemplateHandler, View } from './template-handler';
 import { TRANSLOCO_LANG } from './transloco-lang';
 import { TRANSLOCO_LOADING_TEMPLATE } from './transloco-loading-template';
 import { TRANSLOCO_SCOPE } from './transloco-scope';
 import { TranslocoService } from './transloco.service';
 import { HashMap, MaybeArray, Translation, TranslocoScope } from './types';
-import {
-  listenOrNotOperator,
-  resolveInlineLoader,
-  shouldListenToLangChanges,
-} from './shared';
-import { LangResolver } from './lang-resolver';
-import { ScopeResolver } from './scope-resolver';
 
 type TranslateFn = (key: string, params?: HashMap) => any;
 interface ViewContext {
@@ -83,7 +82,6 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
     @Inject(TRANSLOCO_LOADING_TEMPLATE)
     private providedLoadingTpl: Type<unknown> | string,
     private vcr: ViewContainerRef,
-    private cdr: ChangeDetectorRef,
     private host: ElementRef,
     private renderer: Renderer2
   ) {
@@ -122,7 +120,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
         this.strategy === 'attribute'
           ? this.attributeStrategy()
           : this.structuralStrategy(this.currentLang, this.inlineRead);
-        this.cdr.markForCheck();
+        this.view?.detectChanges();
         this.initialized = true;
       });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

Performance-related refactoring.

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The current behavior is using ChangeDetectorRef#markForCheck that relies on Zone.js and marks the component and its parents as dirty, waiting for the Zone to trigger change detection. This is especially bad for leaf components as it will mark the whole component tree as dirty before being able to update the desired template.

## What is the new behavior?

Uses EmbeddedViewRef#detectChanges only checks the view and its children, which is the smallest unit in the change detection process of a component's template, which gives a performance boost and works zoneless.  

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
