### PR TITLE
feat(transloco-locale): expose default transformers (#435)

### DIFF
--- a/docs/docs/plugins/locale.mdx
+++ b/docs/docs/plugins/locale.mdx
@@ -280,13 +280,18 @@ In some cases you might want to customize the localization transformation, to ac
 There are two types of transformers for date and number:
 
 ```ts title="custom-transformer.ts"
-export class CustomDateTransformer implements TranslocoDateTransformer {
+import { DefaultDateTransformer, DefaultNumberTransformer } from '@ngneat/transloco-locale';
+
+export class CustomDateTransformer extends DefaultDateTransformer {
   public transform(date: Date, locale: Locale, options: DateFormatOptions): string {
     return ...
+
+    // Fallback to default transformer
+    return super.transform(date, locale, options);
   }
 }
 
-export class CustomNumberTransformer implements TranslocoNumberTransformer {
+export class CustomNumberTransformer extends DefaultNumberTransformer {
   public transform(
     value: number | string,
     type: NumberTypes,
@@ -294,6 +299,9 @@ export class CustomNumberTransformer implements TranslocoNumberTransformer {
     options: Intl.NumberFormatOptions
   ): string {
     return ...
+    
+    // Fallback to default transformer
+    return super.transform(value, type, locale, options);
   }
 }
 

--- a/libs/transloco-locale/src/index.ts
+++ b/libs/transloco-locale/src/index.ts
@@ -12,6 +12,8 @@ export {
   TRANSLOCO_NUMBER_TRANSFORMER,
   TranslocoDateTransformer,
   TranslocoNumberTransformer,
+  DefaultDateTransformer,
+  DefaultNumberTransformer,
 } from './lib/transloco-locale.transformers';
 export * from './lib/transloco-locale.types';
 export * from './lib/pipes';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When implementing custom transformers, you can only fallback to the default behaviour by code duplicating code from not exported internal functions of transloco-locale

Issue Number: N/A
Discussion Number: #435

## What is the new behavior?

`DefaultDateTransformer` and `DefaultNumberTransformer` are now exposed to public api, so that they can be referenced and used as fallback in custom implementations.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
