### PR TITLE
fix(transloco): allow multiple functions in translations

### DIFF
--- a/libs/transloco/src/lib/tests/transpiler.spec.ts
+++ b/libs/transloco/src/lib/tests/transpiler.spec.ts
@@ -33,6 +33,11 @@ describe('TranslocoTranspiler', () => {
       expect(parsed).toEqual('LOWERCASE');
     });
 
+    it('should work with multiple functions', () => {
+      const parsed = parser.transpile('first [[ upperCase(second) ]] third [[ upperCase(fourth) ]] fifth', {}, {}, 'key');
+      expect(parsed).toEqual('first SECOND third FOURTH fifth');
+    });
+
     it('should pass the function params', () => {
       const spy = spyOn(transpilerFunctions['upperCase'], 'transpile');
       parser.transpile('[[ upperCase(lowercase) ]]', {}, {}, 'key');

--- a/libs/transloco/src/lib/transloco.transpiler.ts
+++ b/libs/transloco/src/lib/transloco.transpiler.ts
@@ -154,7 +154,7 @@ export class FunctionalTranspiler
     let transpiled = value;
     if (isString(value)) {
       transpiled = value.replace(
-        /\[\[\s*(\w+)\((.*)\)\s*]]/g,
+        /\[\[\s*(\w+)\((.*?)\)\s*]]/g,
         (match: string, functionName: string, args: string) => {
           try {
             const func: TranslocoTranspilerFunction =


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #589 

## What is the new behavior?

Translation strings work with more than one function provided by the FunctionalTranspiler.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
