### PR TITLE
feat(transloco-locale): add sign display number format option

### DIFF
--- a/docs/docs/plugins/locale.mdx
+++ b/docs/docs/plugins/locale.mdx
@@ -245,6 +245,7 @@ Note the format option of the global, locale's format and the one's being passed
 - `maximumFractionDigits`- The maximum number of fraction digits to use. Possible values are from 0 to 20 (default is 3).
 - `minimumSignificantDigits`- The minimum number of significant digits to use. Possible values are from 1 to 21 (default is 1).
 - `maximumSignificantDigits`- The maximum number of significant digits to use. Possible values are from 1 to 21 (default is 21).
+- `signDisplay`- When to display the sign for the number. Possible values are "auto", "always", "exceptZero", "negative", "never" (default is "auto").
 
 ## Date Format Options
 

--- a/libs/transloco-locale/src/lib/transloco-locale.types.ts
+++ b/libs/transloco-locale/src/lib/transloco-locale.types.ts
@@ -22,7 +22,11 @@ export interface NumberFormatOptions {
   /**
    * The maximum number of significant digits to use. Possible values are from 1 to 21
    */
-  maximumSignificantDigits?: number;
+  maximumSignificantDigits?: Intl.NumberFormatOptions['maximumSignificantDigits'];
+  /**
+   * When to display the sign for the number. Possible values are "auto", "always", "exceptZero", "negative", "never"; the default is "auto".
+   */
+  signDisplay?: Intl.NumberFormatOptions['signDisplay'];
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There is no way of providing the option for number sign display without getting type errors or having to use `$any` in the template or `as any` or `as unknown as NumberFormatOptions` in the component.

Issue Number: N/A

## What is the new behavior?

The number sign display can be configured without workarounds or type errors.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```