### PR TITLE
feat(transloco): allow narrowSymbol display option

### DIFF
--- a/libs/transloco-locale/src/lib/pipes/transloco-currency.pipe.ts
+++ b/libs/transloco-locale/src/lib/pipes/transloco-currency.pipe.ts
@@ -31,11 +31,13 @@ export class TranslocoCurrencyPipe
    * 1000000 | translocoCurrency: 'symbol' : {} : USD // $1,000,000.00
    * 1000000 | translocoCurrency: 'name' : {} : USD // 1,000,000.00 US dollars
    * 1000000 | translocoCurrency: 'symbol' : {minimumFractionDigits: 0 } : USD // $1,000,000
+   * 1000000 | translocoCurrency: 'symbol' : {minimumFractionDigits: 0 } : CAD // CA$1,000,000
+   * 1000000 | translocoCurrency: 'narrowSymbol' : {minimumFractionDigits: 0 } : CAD // $1,000,000
    *
    */
   transform(
     value: number | string,
-    display: 'code' | 'symbol' | 'name' = 'symbol',
+    display: 'code' | 'symbol' | 'narrowSymbol' | 'name' = 'symbol',
     numberFormatOptions: NumberFormatOptions = {},
     currencyCode?: Currency,
     locale?: Locale

--- a/libs/transloco-locale/src/lib/tests/pipes/transloco-currency.pipe.spec.ts
+++ b/libs/transloco-locale/src/lib/tests/pipes/transloco-currency.pipe.spec.ts
@@ -46,6 +46,13 @@ describe('TranslocoCurrencyPipe', () => {
     expect(spectator.element).toContainText('€');
   });
 
+  it('should format the currency given narrowSymbol as display argument', () => {
+    spectator = pipeFactory(
+      `{{ '123' | translocoCurrency:'narrowSymbol':{}:'CAD' }}`
+    );
+    expect(spectator.element).toContainText('$');
+  });
+
   it('should use given display', () => {
     spectator = pipeFactory(`{{ '123' | translocoCurrency:'code' }}`);
     const [, { currencyDisplay }] = getIntlCallArgs();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently the `TranslocoCurrencyPipe` supports just `'code' | 'symbol' | 'name'`  currencyDisplay format options, while missing the `narrowSymbol` also suppored by `Intl.NumberFormat()`

## What is the new behavior?
Added an additional option supporting all the Intl.FormatNumber `currencyDisplay ` options.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
The `narrowSymbol` option is particularly useful for currencies like the Canadian Dollar, which has a different standard and narrow symbol.

When you use the `symbol` option for currency display with Canadian Dollars, the output will typically be "CA$". This is the standard symbol for the Canadian Dollar and it clearly differentiates it from other dollar-denominated currencies like the US Dollar (USD), Australian Dollar (AUD), etc.

However, there might be situations where space is limited or where the context makes it clear that the currency is Canadian Dollars. In such cases, you might prefer to use a shorter symbol. This is where the `narrowSymbol` option comes in. For Canadian Dollars, the `narrowSymbol` is "$". It's a more compact representation, but it can also represent other currencies, so it's best used where the currency is clear from the context.

So, the need for `narrowSymbol` arises primarily for space considerations and in contexts where the specific currency is already clear.