### PR TITLE
refactor(transloco): 💡 reverse the scope alias mapping

### DIFF
--- a/libs/transloco/src/lib/tests/service/setTranslation.spec.ts
+++ b/libs/transloco/src/lib/tests/service/setTranslation.spec.ts
@@ -98,7 +98,7 @@ describe('setTranslation', () => {
       service.setTranslation(translation, lang);
       const merged = {
         ...flatten(mockLangs.en),
-        ...flatten({ myScopeAlias: { ...translation } }),
+        ...flatten({ lazyPage: { ...translation } }),
       };
       expect(setTranslationsSpy).toHaveBeenCalledWith('en', merged);
     });

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -276,7 +276,7 @@ export class TranslocoService implements OnDestroy {
       ) as any;
     }
 
-    key = scope ? `${scope}.${key}` : key;
+    key = scope ? `${scope}.${key}` : this.getMappedKey(key);
 
     const translation = this.getTranslation(resolveLang);
     const value = translation[key];
@@ -678,7 +678,7 @@ export class TranslocoService implements OnDestroy {
     if (!this.config.scopeMapping) {
       this.config.scopeMapping = {};
     }
-    this.config.scopeMapping[scope] = alias;
+    this.config.scopeMapping[alias] = toCamelCase(scope);
   }
 
   ngOnDestroy() {
@@ -794,6 +794,19 @@ export class TranslocoService implements OnDestroy {
   private getMappedScope(scope: string): string {
     const { scopeMapping = {} } = this.config;
     return scopeMapping[scope] || toCamelCase(scope);
+  }
+
+  private getMappedKey(key: string): string {
+    const split = key.split('.');
+    if(split.length > 1) {
+      let scope = split.shift();
+      if(scope) {
+        scope = this.getMappedScope(scope);
+        split.unshift(scope);
+        return split.join('.');
+      }
+    }
+    return key;
   }
 
   /**


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: [686](https://github.com/ngneat/transloco/issues/686)

## What is the new behavior?

TranslocoPipe and TranslocoDirective continue to work even if a translatation with the same scope has been made before them (before the resolveScope)
How ?
TranslocoService translations map uses as key the camel case of the scope instead of the alias

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
