### PR TITLE
fix: 🐛 import paths should not end with file suffix

### DIFF
--- a/docs/docs/getting-started/installation.mdx
+++ b/docs/docs/getting-started/installation.mdx
@@ -69,7 +69,7 @@ import { ApplicationConfig, isDevMode } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideTransloco } from '@ngneat/transloco';
 
-import { TranslocoHttpLoader } from './transloco-loader.ts';
+import { TranslocoHttpLoader } from './transloco-loader';
 
 export const appConfig: ApplicationConfig = {
     providers: [

--- a/libs/transloco-schematics/src/ng-add/index.ts
+++ b/libs/transloco-schematics/src/ng-add/index.ts
@@ -132,7 +132,7 @@ export default function (options: SchemaOptions): Rule {
       actions.push(
         addRootProvider(options.project, ({ code, external }) => {
           external('isDevMode', '@angular/core');
-          external('TranslocoHttpLoader', './transloco-loader.ts');
+          external('TranslocoHttpLoader', './transloco-loader');
 
           return code`${external('provideTransloco', '@ngneat/transloco')}({
         config: { 


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
After adding Transloco to an Angular project with standalone configuration you receive a TypeScript error.
`Cannot find module '@ngneat/transloco.ts' or its corresponding type declarations.ts(2307)
`
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
TypeScript error is gone.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
