### PR TITLE
fix(transloco): 🐛 fixed generated scope name in subdirectories

### DIFF
--- a/libs/transloco/src/lib/helpers.ts
+++ b/libs/transloco/src/lib/helpers.ts
@@ -91,6 +91,9 @@ export function toCamelCase(str: string): string {
     .replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) =>
       index == 0 ? word.toLowerCase() : word.toUpperCase()
     )
+    .replace(/\b\/(\w)/g, (_, p1) => 
+      `.${p1.toLowerCase()}`
+    )
     .replace(/\s+|_|-|\//g, '');
 }
 

--- a/libs/transloco/src/lib/tests/i18n-mocks/nested-scope/nested-admin-page/en.json
+++ b/libs/transloco/src/lib/tests/i18n-mocks/nested-scope/nested-admin-page/en.json
@@ -1,0 +1,4 @@
+{
+  "title": "Nested admin english",
+  "read": "Nested admin read english"
+}

--- a/libs/transloco/src/lib/tests/i18n-mocks/nested-scope/nested-admin-page/es.json
+++ b/libs/transloco/src/lib/tests/i18n-mocks/nested-scope/nested-admin-page/es.json
@@ -1,0 +1,4 @@
+{
+  "title": "Nested admin spanish",
+  "read": "Nested admin read spanish"
+}

--- a/libs/transloco/src/lib/tests/scope-resolver.spec.ts
+++ b/libs/transloco/src/lib/tests/scope-resolver.spec.ts
@@ -65,4 +65,17 @@ describe('ScopeResolver', () => {
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith('admin-page', 'adminPage');
   });
+  
+  it('should return provider nested scope with object and set the alias as the scope name if not provided', () => {
+    expect(
+      resolver.resolve({
+        inline: undefined,
+        provider: {
+          scope: 'nested-scope/nested-admin-page'
+        },
+      })
+    ).toEqual('nested-scope/nested-admin-page');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('nested-scope/nested-admin-page', 'nestedScope.nestedAdminPage');
+  })
 });


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 559

## What is the new behavior?

Using a file in a nested directory such as "i18n/nested-scopes/admin-page/en.json" will generate the scope name as "nestedScope.adminPage" rather than "nestedScopeAdminPage".

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
