### PR TITLE
feat(transloco): introduce provideGlobalTranslateFn()

### DIFF
--- a/libs/transloco/src/index.ts
+++ b/libs/transloco/src/index.ts
@@ -62,6 +62,7 @@ export {
   provideTranslocoLoader,
   provideTranslocoScope,
   provideTranslocoLang,
+  provideGlobalTranslateFn,
   TranslocoOptions,
 } from './lib/transloco.providers';
 export { translateSignal, translateObjectSignal } from './lib/transloco.signal';

--- a/libs/transloco/src/lib/tests/service/global-translate-fn.spec.ts
+++ b/libs/transloco/src/lib/tests/service/global-translate-fn.spec.ts
@@ -1,0 +1,20 @@
+import { fakeAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { translate, TranslocoService } from '../../transloco.service';
+import { provideGlobalTranslateFn } from '../../transloco.providers';
+import { mockLangs, providersMock } from '../mocks';
+
+import { loadLang } from './service-spec-utils';
+
+describe('provideGlobalTranslateFn', () => {
+  it(`GIVEN provideGlobalTranslateFn is explicitly added to providers
+      WHEN translate() is called after loading a language
+      THEN should return the translated value`, fakeAsync(() => {
+    const svc = TestBed.configureTestingModule({
+      providers: [providersMock, provideGlobalTranslateFn()],
+    }).inject(TranslocoService);
+    loadLang(svc);
+    expect(translate('home')).toEqual(mockLangs['en'].home);
+  }));
+});

--- a/libs/transloco/src/lib/transloco.providers.ts
+++ b/libs/transloco/src/lib/transloco.providers.ts
@@ -1,10 +1,16 @@
 import {
   EnvironmentProviders,
+  inject,
   makeEnvironmentProviders,
+  provideEnvironmentInitializer,
   Provider,
   Type,
 } from '@angular/core';
 
+import {
+  TranslocoService,
+  setGlobalTranslateService,
+} from './transloco.service';
 import { TRANSLOCO_LOADER, TranslocoLoader } from './transloco.loader';
 import {
   PartialTranslocoConfig,
@@ -40,6 +46,30 @@ import { TRANSLOCO_LANG } from './transloco-lang';
 export interface TranslocoOptions {
   config: PartialTranslocoConfig;
   loader?: Type<TranslocoLoader>;
+}
+
+/**
+ * Wires the standalone {@link translate} and {@link translateObject} functions to the
+ * `TranslocoService` instance, enabling their use outside Angular's DI context
+ * (e.g. class constructors, utility functions, third-party integrations).
+ *
+ * **Omit in SSR** — the module-level reference persists across requests, causing
+ * state leakage between users. In SSR or MFE environments, inject `TranslocoService` directly.
+ *
+ * @example
+ * // app.config.ts
+ * export const appConfig: ApplicationConfig = {
+ *   providers: [
+ *     provideTransloco({ ... }),
+ *     provideGlobalTranslateFn(),
+ *   ],
+ * };
+ */
+export function provideGlobalTranslateFn(): EnvironmentProviders {
+  return provideEnvironmentInitializer(() => {
+    if (typeof ngServerMode !== 'undefined' && ngServerMode) return;
+    setGlobalTranslateService(inject(TranslocoService));
+  });
 }
 
 export function provideTransloco(options: TranslocoOptions) {

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -72,22 +72,58 @@ import {
   resolveInlineLoader,
 } from './utils/scope.utils';
 
-let service: TranslocoService;
+let _service: TranslocoService | undefined;
 
+/**
+ * Standalone version of {@link TranslocoService#translate} for use outside Angular's DI context.
+ * Requires {@link provideGlobalTranslateFn} in your providers. Returns `''` if not initialized.
+ *
+ * @example
+ *
+ * translate<string>('hello')
+ * translate('hello', { value: 'value' })
+ * translate('hello', { }, 'en')
+ */
 export function translate<T = string>(
   key: TranslateParams,
   params: HashMap = {},
   lang?: string,
 ): T {
-  return service.translate<T>(key, params, lang);
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && !_service) {
+    console.warn(
+      '[Transloco] `translate()` was called but `provideGlobalTranslateFn()` has not run.\n' +
+        'Add `provideGlobalTranslateFn()` to your providers, or inject TranslocoService directly.',
+    );
+  }
+
+  return _service?.translate<T>(key, params, lang) ?? ('' as T);
 }
 
+/**
+ * Standalone version of {@link TranslocoService#translateObject} for use outside Angular's DI context.
+ * Requires {@link provideGlobalTranslateFn} in your providers. Returns `[]` if not initialized.
+ *
+ * @example
+ *
+ * translateObject('path.to.object', { subpath: { value: 'someValue' } })
+ */
 export function translateObject<T>(
   key: TranslateParams,
   params: HashMap = {},
   lang?: string,
 ): T | T[] {
-  return service.translateObject<T>(key, params, lang);
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && !_service) {
+    console.warn(
+      '[Transloco] `translateObject()` was called but `provideGlobalTranslateFn()` has not run.\n' +
+        'Add `provideGlobalTranslateFn()` to your providers, or inject TranslocoService directly.',
+    );
+  }
+
+  return _service?.translateObject<T>(key, params, lang) ?? [];
+}
+
+export function setGlobalTranslateService(service: TranslocoService): void {
+  _service = service;
 }
 
 export class TranslationLoadError extends Error {
@@ -158,7 +194,6 @@ export class TranslocoService {
     if (!this.loader) {
       this.loader = new DefaultLoader(this.translations);
     }
-    service = this;
     this.config = JSON.parse(JSON.stringify(userConfig));
 
     this.setAvailableLangs(this.config.availableLangs || []);

--- a/nx.json
+++ b/nx.json
@@ -177,5 +177,6 @@
     "releaseTag": {
       "pattern": "releases/{version}"
     }
-  }
+  },
+  "analytics": false
 }


### PR DESCRIPTION
Replaces the implicit auto-wiring of the standalone translate() and
translateObject() functions with an explicit opt-in provider.

Previously, TranslocoService assigned itself to a module-level variable
in its constructor, making the standalone functions work automatically
but with no way to opt out. This is problematic in SSR (the reference
persists across requests, leaking state between users) and in MFE setups
with multiple Angular instances.

provideGlobalTranslateFn() wires the functions explicitly via
provideEnvironmentInitializer, consistent with the rest of the provide*
API surface. Apps that don't need the standalone functions — SSR, MFE —
simply omit it.

BREAKING CHANGE: translate() and translateObject() now require
provideGlobalTranslateFn() in the application providers. Without it
they return '' / [] and emit a dev-mode warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Angular environment provider to wire global translation helper functions to the active translation service.
  * Re-exported the new provider from the package entry point.
* **Bug Fixes**
  * Global translation helpers now fail safely if invoked before initialization (returning empty values instead of throwing).
  * Added dev-mode warnings when global translation helpers are called before setup.
* **Tests**
  * Added coverage to verify the global translation provider works when registered in Angular test setups.
* **Chores**
  * Disabled Nx analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->