### PR TITLE
feat(transloco): expose activeLang signal on TranslocoService

### DIFF
--- a/libs/transloco/src/lib/tests/service/activeLang.spec.ts
+++ b/libs/transloco/src/lib/tests/service/activeLang.spec.ts
@@ -1,0 +1,30 @@
+import { createService } from '../mocks';
+import { TranslocoService } from '../../transloco.service';
+
+describe('activeLang', () => {
+  let service: TranslocoService;
+
+  beforeEach(() => (service = createService()));
+
+  it(`GIVEN a newly initialized service
+      WHEN activeLang is read
+      THEN it should return the default language`, () => {
+    expect(service.activeLang()).toBe('en');
+  });
+
+  it(`GIVEN a service with a default language
+      WHEN setActiveLang is called with a new language
+      THEN activeLang signal should reflect the new language`, () => {
+    service.setActiveLang('es');
+    expect(service.activeLang()).toBe('es');
+  });
+
+  it(`GIVEN a service
+      WHEN setActiveLang is called multiple times
+      THEN activeLang signal should always reflect the latest language`, () => {
+    service.setActiveLang('es');
+    expect(service.activeLang()).toBe('es');
+    service.setActiveLang('en');
+    expect(service.activeLang()).toBe('en');
+  });
+});

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -4,6 +4,7 @@ import {
   Inject,
   Injectable,
   Optional,
+  type Signal,
 } from '@angular/core';
 import {
   BehaviorSubject,
@@ -21,7 +22,7 @@ import {
   switchMap,
   tap,
 } from 'rxjs';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { isEmpty, isNil, isString, size, toCamelCase } from '@jsverse/utils';
 
 import {
@@ -123,6 +124,17 @@ export class TranslocoService {
     scopeMapping?: HashMap<string>;
   };
 
+  /**
+   * A signal that reflects the currently active language.
+   *
+   * @example
+   *
+   * const upper = computed(() => this.transloco.activeLang().toUpperCase());
+   *
+   * const lang = linkedSignal(() => this.transloco.activeLang());
+   */
+  readonly activeLang: Signal<string>;
+
   private destroyRef = inject(DestroyRef);
   private destroyed = false;
 
@@ -149,6 +161,8 @@ export class TranslocoService {
     // Don't use distinctUntilChanged as we need the ability to update
     // the value when using setTranslation or setTranslationKeys
     this.langChanges$ = this.lang.asObservable();
+
+    this.activeLang = toSignal(this.lang, { requireSync: true });
 
     /**
      * When we have a failure, we want to define the next language that succeeded as the active


### PR DESCRIPTION
Adds a `Signal<string>` property `activeLang` derived from the internal `lang` BehaviorSubject via `toSignal` with `requireSync: true`, enabling signal-based reactivity (e.g. inside `computed` or `linkedSignal`) without subscribing to `langChanges$`.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `activeLang` as a `Signal<string>` on `TranslocoService` to enable signal-based reactivity of the current language (e.g., in `computed` or `linkedSignal`) without subscribing to `langChanges$`.

<sup>Written for commit 140ad2b11b8b6dbb8b43a3da74a5788a3a57e7d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time access to the currently active language value.

* **Tests**
  * Added comprehensive tests for language state management, verifying default behavior, updates, and state consistency across language changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->