### PR TITLE
fix(transloco): memory leak due global service reference not being cleaned up

### DIFF
--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -72,13 +72,20 @@ import {
   resolveInlineLoader,
 } from './utils/scope.utils';
 
-let service: TranslocoService;
+let service: TranslocoService | undefined;
 
 export function translate<T = string>(
   key: TranslateParams,
   params: HashMap = {},
   lang?: string,
 ): T {
+  if (!service) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      console.warn('No active TranslocoService found');
+    }
+    return '' as T;
+  }
+
   return service.translate<T>(key, params, lang);
 }
 
@@ -87,6 +94,13 @@ export function translateObject<T>(
   params: HashMap = {},
   lang?: string,
 ): T | T[] {
+  if (!service) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      console.warn('No active TranslocoService found');
+    }
+    return [];
+  }
+
   return service.translateObject<T>(key, params, lang);
 }
 
@@ -190,6 +204,11 @@ export class TranslocoService {
       // Cached values retain `this`, causing circular references that block garbage collection,
       // leading to memory leaks during server-side rendering.
       this.cache.clear();
+
+      // Cleanup global service reference to prevent memory leaks.
+      if (service === this) {
+        service = undefined;
+      }
     });
   }
 


### PR DESCRIPTION
This pull request is meant to prevent a memory leak when the `TranslocoService` is destroyed, but the global `service` reference is kept alive.

We're running into this issue with a micro frontend architecture, where the `TranslocoService` is not garbage collected after the Angular application that uses it, is swapped out for another MFE application.

To solve the issue, this PR sets the `service` to `undefined` during the destroy lifecycle phase. As a safety feature this will only be done if the service being destroyed matches the current value held by `service` in case multiple micro frontends are active, where each could be having their own instance of the `TranslocoService`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory leak by clearing the global `service` reference when a `TranslocoService` instance is destroyed. Also adds guards to handle calls when no active service is available, which is common in micro frontend swaps.

- **Bug Fixes**
  - Set global `service` to `undefined` during destroy when it matches the instance, enabling garbage collection.
  - Updated `translate` and `translateObject` to safely handle missing service: log a dev warning and return `''` or `[]`.

<sup>Written for commit 789bfe2baf3caf4873cee42bd86fd12c0ce82e07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jsverse/transloco/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the translation service to gracefully handle uninitialized service states by returning safe empty values instead of failing
  * Improved service cleanup to properly clear stale references and prevent memory retention

<!-- end of auto-generated comment: release notes by coderabbit.ai -->