### PR TITLE
fix: translateSignal utility missing injector for toSignal

### DIFF
--- a/libs/transloco/src/lib/tests/signal.spec.ts
+++ b/libs/transloco/src/lib/tests/signal.spec.ts
@@ -1,4 +1,11 @@
-import { Component, signal } from '@angular/core';
+import {
+  Component,
+  inject,
+  Injector,
+  OnInit,
+  Signal,
+  signal,
+} from '@angular/core';
 import { fakeAsync, TestBed } from '@angular/core/testing';
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 
@@ -15,9 +22,13 @@ import { providersMock, runLoader } from './mocks';
     <div id="textObject">{{ translatedObject().title }}</div>
     <div id="dynamicKey">{{ translatedDynamicKey() }}</div>
     <div id="dynamicParam">{{ translatedDynamicParam() }}</div>
+    <div id="outsideInjectionContextText">
+      {{ outsideInjectionContextTranslatedText() }}
+    </div>
   `,
 })
-class TestComponent {
+class TestComponent implements OnInit {
+  private readonly injector = inject(Injector);
   translatedText = translateSignal('home');
   translatedObject = translateObjectSignal('nested');
 
@@ -34,6 +45,17 @@ class TestComponent {
     this.dynamicKey,
     this.dynamicParam,
   );
+
+  outsideInjectionContextTranslatedText: Signal<string> = signal('UNDEFINED');
+
+  ngOnInit(): void {
+    this.outsideInjectionContextTranslatedText = translateSignal(
+      'home',
+      undefined,
+      undefined,
+      this.injector,
+    );
+  }
 
   changeKey(key: string) {
     this.dynamicKey.set(key);
@@ -59,6 +81,18 @@ describe('translateSignal in component', () => {
     runLoader();
     spectator.detectChanges();
     expect(spectator.query('#text')).toHaveText('home english');
+  }));
+
+  it(`GIVEN translateSignal with static key
+      OUTSIDE OF INJECTION CONTEXT
+      WHEN translations are loaded
+      THEN should display translated text`, fakeAsync(() => {
+    spectator = createComponent();
+    runLoader();
+    spectator.detectChanges();
+    expect(spectator.query('#outsideInjectionContextText')).toHaveText(
+      'home english',
+    );
   }));
 
   it(`GIVEN translateSignal with dynamic key

--- a/libs/transloco/src/lib/tests/signal.spec.ts
+++ b/libs/transloco/src/lib/tests/signal.spec.ts
@@ -9,6 +9,7 @@ import {
 import { fakeAsync, TestBed } from '@angular/core/testing';
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 
+import { Translation } from '../transloco.types';
 import { TranslocoModule } from '../transloco.module';
 import { TranslocoTestingModule } from '../transloco-testing.module';
 import { translateSignal, translateObjectSignal } from '../transloco.signal';
@@ -25,6 +26,11 @@ import { providersMock, runLoader } from './mocks';
     <div id="outsideInjectionContextText">
       {{ outsideInjectionContextTranslatedText() }}
     </div>
+    @if (outsideInjectionContextTranslatedObject(); as object) {
+      <div id="outsideInjectionContextObject">
+        {{ object.title }}
+      </div>
+    }
   `,
 })
 class TestComponent implements OnInit {
@@ -47,6 +53,8 @@ class TestComponent implements OnInit {
   );
 
   outsideInjectionContextTranslatedText: Signal<string> = signal('UNDEFINED');
+  outsideInjectionContextTranslatedObject: Signal<Translation | undefined> =
+    signal(undefined);
 
   ngOnInit(): void {
     this.outsideInjectionContextTranslatedText = translateSignal(
@@ -55,6 +63,21 @@ class TestComponent implements OnInit {
       undefined,
       this.injector,
     );
+    this.outsideInjectionContextTranslatedObject = translateObjectSignal(
+      'nested',
+      undefined,
+      undefined,
+      this.injector,
+    );
+  }
+
+  setOutsideInjectionContextTranslatedTextWithoutInjector(): void {
+    this.outsideInjectionContextTranslatedText = translateSignal('home');
+  }
+
+  setOutsideInjectionContextTranslatedObjectWithoutInjector(): void {
+    this.outsideInjectionContextTranslatedObject =
+      translateObjectSignal('nested');
   }
 
   changeKey(key: string) {
@@ -83,9 +106,8 @@ describe('translateSignal in component', () => {
     expect(spectator.query('#text')).toHaveText('home english');
   }));
 
-  it(`GIVEN translateSignal with static key
-      OUTSIDE OF INJECTION CONTEXT
-      WHEN translations are loaded
+  it(`GIVEN translateSignal with static key outside of an injection context
+      WHEN translations are loaded with injector
       THEN should display translated text`, fakeAsync(() => {
     spectator = createComponent();
     runLoader();
@@ -93,6 +115,19 @@ describe('translateSignal in component', () => {
     expect(spectator.query('#outsideInjectionContextText')).toHaveText(
       'home english',
     );
+  }));
+
+  it(`GIVEN translateSignal with static key outside of an injection context
+      WHEN translations are loaded without injector
+      THEN should throw error`, fakeAsync(() => {
+    spectator = createComponent();
+    runLoader();
+    expect(() =>
+      spectator.component.setOutsideInjectionContextTranslatedTextWithoutInjector(),
+    ).toThrow();
+
+    spectator.detectChanges();
+    expect(spectator.query('#outsideInjectionContextText')).toHaveText('');
   }));
 
   it(`GIVEN translateSignal with dynamic key
@@ -135,6 +170,29 @@ describe('translateObjectSignal in component', () => {
     runLoader();
     spectator.detectChanges();
     expect(spectator.query('#textObject')).toHaveText('Title english');
+  }));
+
+  it(`GIVEN translateObjectSignal with static key outside of an injection context
+      WHEN translations are loaded with injector
+      THEN should return translation object`, fakeAsync(() => {
+    spectator = createComponent();
+    runLoader();
+    spectator.detectChanges();
+    expect(spectator.query('#outsideInjectionContextObject')).toHaveText(
+      'Title english',
+    );
+  }));
+
+  it(`GIVEN translateObjectSignal with static key outside of an injection context
+      WHEN translations are loaded without injector
+      THEN should throw error`, fakeAsync(() => {
+    spectator = createComponent();
+    runLoader();
+    expect(() =>
+      spectator.component.setOutsideInjectionContextTranslatedObjectWithoutInjector(),
+    ).toThrow();
+    spectator.detectChanges();
+    expect(spectator.query('#outsideInjectionContextObject')).toHaveText('');
   }));
 
   it(`GIVEN translateObjectSignal with dynamic key

--- a/libs/transloco/src/lib/tests/signal.spec.ts
+++ b/libs/transloco/src/lib/tests/signal.spec.ts
@@ -122,12 +122,10 @@ describe('translateSignal in component', () => {
       THEN should throw error`, fakeAsync(() => {
     spectator = createComponent();
     runLoader();
+    spectator.detectChanges();
     expect(() =>
       spectator.component.setOutsideInjectionContextTranslatedTextWithoutInjector(),
     ).toThrow();
-
-    spectator.detectChanges();
-    expect(spectator.query('#outsideInjectionContextText')).toHaveText('');
   }));
 
   it(`GIVEN translateSignal with dynamic key
@@ -188,11 +186,10 @@ describe('translateObjectSignal in component', () => {
       THEN should throw error`, fakeAsync(() => {
     spectator = createComponent();
     runLoader();
+    spectator.detectChanges();
     expect(() =>
       spectator.component.setOutsideInjectionContextTranslatedObjectWithoutInjector(),
     ).toThrow();
-    spectator.detectChanges();
-    expect(spectator.query('#outsideInjectionContextObject')).toHaveText('');
   }));
 
   it(`GIVEN translateObjectSignal with dynamic key

--- a/libs/transloco/src/lib/transloco.signal.ts
+++ b/libs/transloco/src/lib/transloco.signal.ts
@@ -105,7 +105,10 @@ export function translateObjectSignal<T extends TranslateSignalKey>(
       ),
     );
   });
-  return toSignal(result, { initialValue: Array.isArray(key) ? [] : {} });
+  return toSignal(result, {
+    initialValue: Array.isArray(key) ? [] : {},
+    injector,
+  });
 }
 
 function computerParams(params: HashMap<Signal<string>> | Signal<HashMap>) {

--- a/libs/transloco/src/lib/transloco.signal.ts
+++ b/libs/transloco/src/lib/transloco.signal.ts
@@ -64,7 +64,10 @@ export function translateSignal<T extends TranslateSignalKey>(
       ),
     );
   });
-  return toSignal(result, { initialValue: Array.isArray(key) ? [''] : '' });
+  return toSignal(result, {
+    initialValue: Array.isArray(key) ? [''] : '',
+    injector,
+  });
 }
 
 /**


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`translateSignal` does not work outside of injection context.

Issue Number: #901

## What is the new behavior?
Add `injector` to `toSignal`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `translateSignal` and `translateObjectSignal` to work outside Angular’s injection context by passing an `injector` to `toSignal`. Tests cover using `Injector` and assert errors when it’s missing without relying on DOM checks.

- **Bug Fixes**
  - Pass `injector` to `toSignal` in `translateSignal` and `translateObjectSignal`.
  - Add tests for outside injection context: success with `Injector`; throws when missing (no DOM-based assertions).
  - No API changes.

<sup>Written for commit 82df6df7e96784fa8cd0cffafc2704b551992591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jsverse/transloco/pull/926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Translation signals now preserve the injection context when created, improving translation reliability when used outside typical component contexts.

* **Tests**
  * New tests verify translation signals work when provided an injection context and fail/throw as expected when not, ensuring consistent rendering of translated text and objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->