### PR TITLE
ci(release): surface resolved version in dry-run summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       # `id: version` exposes the resolved version via
-      # steps.version.outputs.value. nx prints "New version X.Y.Z written to
-      # ..." in BOTH real and dry-run modes, so parsing it surfaces a useful
-      # preview even on a dry-run where package.json is left untouched
+      # steps.version.outputs.value (drives the changelog + GitHub release tag).
+      # Real run: read the bumped package.json — the authoritative source for
+      # what gets built/published/tagged, and a stable JSON contract.
+      # Dry run: package.json is left untouched, so parse nx's "New version
+      # X.Y.Z written to ..." line instead (preview only; consuming steps are
+      # all skipped, so a parse miss here is harmless)
       - name: Version
         id: version
         env:
@@ -110,7 +113,11 @@ jobs:
           else
             npx nx release version "$BUMP" --verbose $DRY | tee /tmp/nx-version.log
           fi
-          VERSION=$(grep -oiE 'New version [0-9]+\.[0-9]+\.[0-9]+[0-9A-Za-z.+-]*' /tmp/nx-version.log | head -1 | awk '{print $3}')
+          if [[ "$DRY_RUN" == "true" ]]; then
+            VERSION=$(grep -oiE 'New version [0-9]+\.[0-9]+\.[0-9]+[0-9A-Za-z.+-]*' /tmp/nx-version.log | head -1 | awk '{print $3}')
+          else
+            VERSION=$(node -p "require('./libs/transloco/package.json').version")
+          fi
           echo "value=${VERSION:-unknown}" >> "$GITHUB_OUTPUT"
 
       # Build AFTER version so dist/ package.json files carry the bumped version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,34 +92,30 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # `id: version` exposes the resolved version via
+      # steps.version.outputs.value. nx prints "New version X.Y.Z written to
+      # ..." in BOTH real and dry-run modes, so parsing it surfaces a useful
+      # preview even on a dry-run where package.json is left untouched
       - name: Version
+        id: version
         env:
           BUMP: ${{ inputs.bump }}
           DRY_RUN: ${{ inputs.dry-run }}
         run: |
+          set -o pipefail
           DRY=""
           if [[ "$DRY_RUN" == "true" ]]; then DRY="--dry-run"; fi
           if [[ "$BUMP" == "auto" ]]; then
-            npx nx release version --verbose $DRY
+            npx nx release version --verbose $DRY | tee /tmp/nx-version.log
           else
-            npx nx release version "$BUMP" --verbose $DRY
+            npx nx release version "$BUMP" --verbose $DRY | tee /tmp/nx-version.log
           fi
+          VERSION=$(grep -oiE 'New version [0-9]+\.[0-9]+\.[0-9]+[0-9A-Za-z.+-]*' /tmp/nx-version.log | head -1 | awk '{print $3}')
+          echo "value=${VERSION:-unknown}" >> "$GITHUB_OUTPUT"
 
       # Build AFTER version so dist/ package.json files carry the bumped version
       - name: Build
         run: npm run ci:build
-
-      - name: Read version
-        id: version
-        env:
-          DRY_RUN: ${{ inputs.dry-run }}
-        run: |
-          if [[ "$DRY_RUN" == "true" ]]; then
-            echo "value=n/a (dry-run)" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          VERSION=$(node -p "require('./libs/transloco/package.json').version")
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
       # Skipped on dry-run: the version on disk is unchanged, so `npm publish
       # --dry-run` would always collide with the already-published version


### PR DESCRIPTION
## Summary

Follow-up to #924. The release workflow's run summary printed `Version: n/a (dry-run)` on dry runs — useless for the one thing a dry run is *for*: previewing the version that would be released.

Root cause: the `Read version` step read `libs/transloco/package.json`, but `nx release version --dry-run` intentionally leaves that file untouched. #924 avoided reporting the stale on-disk (current) version by emitting `n/a` instead — correct, but uninformative.

## Fix

The `Version` step now owns `id: version` and resolves the version from the right source per mode:

- **Real run** — reads the bumped `libs/transloco/package.json`. This is authoritative (it's exactly what gets built into `dist/`, published, tagged, and changelogged) and a stable JSON contract. `steps.version.outputs.value` drives the changelog step and the GitHub Release tag, so robustness matters: a brittle source that failed *after* a successful publish would leave a half-finished release.
- **Dry run** — `package.json` is untouched, so parse nx's `New version X.Y.Z written to ...` line instead. Preview only; every consuming step is skipped on a dry run, so a parse miss here is harmless.

The separate `Read version` step is folded into `Version`. `set -o pipefail` is added so a failed `nx release version` fails the step rather than being masked by the `tee` pipe.

A dry run now reports the actual planned version:

```
- Version: `8.3.1`
- Bump input: `auto`
- Dry run: `true`
```

## Test plan

- [x] actionlint passes
- [x] Dry-run version-extraction regex verified locally against normal (`8.3.1`) and prerelease (`8.3.1-0`) output
- [ ] After merge: dispatch with `dry-run: true`, `bump: auto` — confirm the summary shows the real planned version instead of `n/a`

## Context

Verified against the dry run from #924 ([run 27462176141](https://github.com/jsverse/transloco/actions/runs/27462176141)): it behaved correctly (all mutating steps skipped) but the summary line was unhelpful. This addresses only that reporting gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release workflow by consolidating version resolution into a single step.
  * Improved version detection for dry-run and real runs, writing a consistent output value (falls back to "unknown" on parse failure).
  * Removed a redundant version-read step so build starts immediately after version resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->