### PR TITLE
ci(release): authenticate release pushes via GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,13 +62,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      # checkout defaults its token to github.token (GITHUB_TOKEN) and persists
-      # it, which the later git push relies on — no need to pass it explicitly
+      # Mint a short-lived GitHub App installation token. The app is a bypass
+      # actor on the master branch ruleset, so the release commit/tag push below
+      # is authorized while humans still go through PRs + status checks. The
+      # token is auto-revoked when the job ends (effective lifetime ≈ job run)
+      # and is scoped to repo Contents only.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      # Persist the app token so the later `git push HEAD:master` authenticates
+      # as the bypass-capable app — the default GITHUB_TOKEN cannot push to the
+      # protected branch (rejected with GH006)
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ steps.app-token.outputs.token }}
 
       # Node >= 22.14 and npm >= 11.5.1 are required for npm OIDC trusted
       # publishing (node 22 still bundles npm 10); node 24 is not yet
@@ -145,10 +159,13 @@ jobs:
         if: ${{ !inputs.dry-run }}
         run: git push --follow-tags origin HEAD:master
 
+      # Use the app token (not the default GITHUB_TOKEN): nx release changelog
+      # both creates the GitHub Release and may push the changelog commit, so it
+      # needs the bypass-capable identity for the push to protected master.
       - name: Changelog and GitHub release
         if: ${{ !inputs.dry-run }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: npx nx release changelog ${{ steps.version.outputs.value }} --verbose
 
       # The changelog step commits CHANGELOG.md locally — push it too

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,24 +134,6 @@ jobs:
       - name: Build
         run: npm run ci:build
 
-      # Always runs. On a dry run, --dry-run packs the tarballs and exercises
-      # the publish path (version, packageRoot, tag, access) without uploading
-      # — note this does NOT exercise OIDC auth, which only a real publish does.
-      # Prereleases go to the `next` dist-tag so `npm i @jsverse/transloco`
-      # (latest) never resolves to a prerelease version. Provenance
-      # attestations are generated automatically with trusted publishing —
-      # no --provenance flag needed
-      - name: Publish to npm (OIDC trusted publishing + provenance)
-        env:
-          BUMP: ${{ inputs.bump }}
-          DRY_RUN: ${{ inputs.dry-run }}
-        run: |
-          TAG="latest"
-          if [[ "$BUMP" == "prerelease" ]]; then TAG="next"; fi
-          DRY=()
-          if [[ "$DRY_RUN" == "true" ]]; then DRY=(--dry-run); fi
-          npx nx release publish --access public --tag "$TAG" --verbose "${DRY[@]}"
-
       # The releases/{version} tag must be on the remote BEFORE the changelog
       # step creates the GitHub release, otherwise the API invents the tag at
       # the old master HEAD
@@ -172,6 +154,28 @@ jobs:
       - name: Push changelog commit
         if: ${{ !inputs.dry-run }}
         run: git push origin HEAD:master
+
+      # Publish LAST: npm publish is irreversible, so it runs only after every
+      # fallible git step (push to protected master, changelog, tag push) has
+      # succeeded — preventing the npm-ahead-of-git split-brain that left 8.4.0
+      # published while master stayed un-updated. Re-running is safe: nx skips
+      # versions already on the registry. Always runs; on a dry run, --dry-run
+      # packs the tarballs and exercises the publish path (version, packageRoot,
+      # tag, access) without uploading — note this does NOT exercise OIDC auth,
+      # which only a real publish does. Prereleases go to the `next` dist-tag so
+      # `npm i @jsverse/transloco` (latest) never resolves to a prerelease.
+      # Provenance attestations are generated automatically with trusted
+      # publishing — no --provenance flag needed.
+      - name: Publish to npm (OIDC trusted publishing + provenance)
+        env:
+          BUMP: ${{ inputs.bump }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          TAG="latest"
+          if [[ "$BUMP" == "prerelease" ]]; then TAG="next"; fi
+          DRY=()
+          if [[ "$DRY_RUN" == "true" ]]; then DRY=(--dry-run); fi
+          npx nx release publish --access public --tag "$TAG" --verbose "${DRY[@]}"
 
       - name: Summary
         if: always()

--- a/nx.json
+++ b/nx.json
@@ -102,6 +102,7 @@
       "automaticFromRef": true,
       "git": {
         "commit": true,
+        "tag": false,
         "commitArgs": "--no-verify"
       },
       "workspaceChangelog": {


### PR DESCRIPTION
## Why

The release workflow authenticates the `git push HEAD:master` (version bump + tag, then changelog commit) with the default `GITHUB_TOKEN`. `master` is a protected branch, so the push is rejected:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
remote: - You're not authorized to push to this branch.
```

This is exactly what failed the 8.4.0 run: npm published, the tag slipped through (tags aren't branch-protected), but the commit push to `master` was declined — leaving the changelog + GitHub Release uncreated, with npm ahead of git. `GITHUB_TOKEN` can **never** bypass branch protection, so the fix is a bypass-capable identity.

## What

- **Auth via a GitHub App token.** `actions/create-github-app-token@v2` mints a short-lived installation token, used for `checkout` (persisted for the push) and for the changelog step's `GITHUB_TOKEN`. Auto-revokes at job end (effective lifetime ≈ job duration), scoped to repo **Contents** only — strictly tighter than a PAT. Humans still go through PRs + status checks; only the release bot pushes directly.
- **Fix a latent double-tag failure.** `changelog.git.tag` defaults to `true` in nx, so `nx release changelog` tried to re-create the `releases/{version}` tag that `nx release version` already made → "tag already exists", aborting the step (hit during 8.4.0 recovery). Set `changelog.git.tag: false` so only the version phase tags.
- **Publish to npm last.** npm publish is irreversible, so it now runs *after* every fallible git step (push to protected master, changelog, tag push). Previously it ran 3rd, so a push failure left npm ahead of git — the 8.4.0 split-brain. Re-running is safe: nx skips versions already on the registry.

## Required manual setup before merge / next release

1. **Create a GitHub App** (org-owned, `jsverse`) with **Contents: Read & write** only; no webhook; install on the `transloco` repo.
2. **Add secrets:** `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`.
3. **Add the App as a bypass actor** on the `master` branch ruleset (convert the classic branch-protection rule to a ruleset if needed — classic rules have limited App-bypass support).

## Verify

Run the workflow with **dry-run = false** after setup. Dry-run validates build/pack but does **not** exercise the push or OIDC, so the protected-branch path is only proven by a real run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow’s authentication for protected branch updates by using a short-lived installation token for GitHub operations.
  * Updated the release sequence so changelog/release creation runs with the correct token context after commit/tag operations.
  * Disabled automatic git tag creation during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->