### PR TITLE
fix(locale): respect currency in numberFormatOptions

### DIFF
--- a/libs/transloco-locale/src/lib/pipes/transloco-currency.pipe.ts
+++ b/libs/transloco-locale/src/lib/pipes/transloco-currency.pipe.ts
@@ -48,7 +48,10 @@ export class TranslocoCurrencyPipe
       ...getDefaultOptions(locale, 'currency', this.localeConfig),
       ...numberFormatOptions,
       currencyDisplay: display,
-      currency: currencyCode || this.localeService._resolveCurrencyCode(),
+      currency:
+        currencyCode ||
+        numberFormatOptions.currency ||
+        this.localeService._resolveCurrencyCode(),
     };
 
     return this.localeService.localizeNumber(

--- a/libs/transloco-locale/src/lib/tests/pipes/transloco-currency.pipe.spec.ts
+++ b/libs/transloco-locale/src/lib/tests/pipes/transloco-currency.pipe.spec.ts
@@ -63,6 +63,24 @@ describe('TranslocoCurrencyPipe', () => {
     expect(spectator.element).toContainText('$');
   });
 
+  it(`GIVEN EUR as the currency field on numberFormatOptions
+      WHEN transforming to currency without the currencyCode argument
+      THEN it should use the currency from numberFormatOptions`, () => {
+    spectator = pipeFactory(
+      `{{ '123' | translocoCurrency:'symbol':{currency:'EUR'} }}`,
+    );
+    expect(spectator.element).toContainText('€');
+  });
+
+  it(`GIVEN a currencyCode argument and a different currency on numberFormatOptions
+      WHEN transforming to currency
+      THEN the currencyCode argument should take precedence`, () => {
+    spectator = pipeFactory(
+      `{{ '123' | translocoCurrency:'symbol':{currency:'EUR'}:'CAD' }}`,
+    );
+    expect(spectator.element).toContainText('CA$');
+  });
+
   it(`GIVEN code as display parameter
       WHEN transforming to currency
       THEN it should use code display format`, () => {


### PR DESCRIPTION
Fixes #934

`TranslocoCurrencyPipe` ignores the `currency` field on `numberFormatOptions`. Calling it like this while the active locale is `en`:

```ts
translocoCurrencyPipe.transform(10, 'symbol', { currency: 'EUR' });
```

returns `$10.00` instead of `€10.00`, because the pipe always builds its options with:

```ts
currency: currencyCode || this.localeService._resolveCurrencyCode(),
```

That line runs after `...numberFormatOptions` is spread into the same object, so it overwrites whatever `currency` the caller passed in, even though `currency` is a documented, typed field on `NumberFormatOptions`. The only way to actually set a currency was the separate `currencyCode` positional argument, which doesn't match what the type suggests should work.

The fix falls back to `numberFormatOptions.currency` before resolving the locale default, while still letting the `currencyCode` argument win if both are given, so nothing that currently relies on `currencyCode` changes behavior:

```ts
currency:
  currencyCode ||
  numberFormatOptions.currency ||
  this.localeService._resolveCurrencyCode(),
```

Added two spec cases to `transloco-currency.pipe.spec.ts`: one confirming `numberFormatOptions.currency` is now honored, and one confirming `currencyCode` still takes precedence when both are passed. Ran `nx test transloco-locale` locally (51/51 passing, including the new cases) and `nx lint transloco-locale` (clean). I also reverted the pipe change on its own and reran the suite to confirm the new test actually fails without the fix, so it's a real regression test and not a false positive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Currency formatting now respects a configured currency value when no explicit currency is passed, while still prioritizing an explicitly provided currency argument.
  * Added test coverage to confirm the expected currency selection behavior in both fallback and override cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->